### PR TITLE
feat: add repository settings to mirror creation page to disable actions

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
       "version": "0.1.0",
       "license": "MIT",
       "dependencies": {
+        "@hookform/resolvers": "3.7.0",
         "@octokit/auth-app": "6.1.1",
         "@octokit/graphql-schema": "15.18.1",
         "@primer/octicons-react": "19.9.0",
@@ -27,6 +28,7 @@
         "proxy-agent": "6.4.0",
         "react": "18.3.1",
         "react-dom": "18.3.1",
+        "react-hook-form": "7.52.1",
         "simple-git": "3.25.0",
         "styled-components": "5.3.11",
         "superjson": "2.2.1",
@@ -2041,6 +2043,14 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/@hapi/bourne/-/bourne-2.1.0.tgz",
       "integrity": "sha512-i1BpaNDVLJdRBEKeJWkVO6tYX6DMFBuwMhSuWqLsY4ufeTKGVuV5rBsUhxPayXqnnWHgXUAmWK16H/ykO5Wj4Q=="
+    },
+    "node_modules/@hookform/resolvers": {
+      "version": "3.7.0",
+      "resolved": "https://registry.npmjs.org/@hookform/resolvers/-/resolvers-3.7.0.tgz",
+      "integrity": "sha512-42p5X18noBV3xqOpTlf2V5qJZwzNgO4eLzHzmKGh/w7z4+4XqRw5AsESVkqE+qwAuRRlg2QG12EVEjPkrRIbeg==",
+      "peerDependencies": {
+        "react-hook-form": "^7.0.0"
+      }
     },
     "node_modules/@humanwhocodes/config-array": {
       "version": "0.11.14",
@@ -12731,6 +12741,21 @@
       },
       "peerDependencies": {
         "react": "^18.3.1"
+      }
+    },
+    "node_modules/react-hook-form": {
+      "version": "7.52.1",
+      "resolved": "https://registry.npmjs.org/react-hook-form/-/react-hook-form-7.52.1.tgz",
+      "integrity": "sha512-uNKIhaoICJ5KQALYZ4TOaOLElyM+xipord+Ha3crEFhTntdLvWZqVY49Wqd/0GiVCA/f9NjemLeiNPjG7Hpurg==",
+      "engines": {
+        "node": ">=12.22.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/react-hook-form"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17 || ^18 || ^19"
       }
     },
     "node_modules/react-intersection-observer": {

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
     "prepare": "test -d node_modules/husky && husky || echo \"husky is not installed\""
   },
   "dependencies": {
+    "@hookform/resolvers": "3.7.0",
     "@octokit/auth-app": "6.1.1",
     "@octokit/graphql-schema": "15.18.1",
     "@primer/octicons-react": "19.9.0",
@@ -37,6 +38,7 @@
     "proxy-agent": "6.4.0",
     "react": "18.3.1",
     "react-dom": "18.3.1",
+    "react-hook-form": "7.52.1",
     "simple-git": "3.25.0",
     "styled-components": "5.3.11",
     "superjson": "2.2.1",

--- a/src/app/[organizationId]/forks/[forkId]/page.tsx
+++ b/src/app/[organizationId]/forks/[forkId]/page.tsx
@@ -36,6 +36,7 @@ import Fuse from 'fuse.js'
 import { useForkData } from 'hooks/useFork'
 import { useOrgData } from 'hooks/useOrganization'
 import { useCallback, useState } from 'react'
+import { RepositorySettingsSchema } from 'server/repos/schema'
 
 const Fork = () => {
   const { organizationId } = useParams()
@@ -204,9 +205,11 @@ const Fork = () => {
     async ({
       repoName,
       branchName,
+      settings,
     }: {
       repoName: string
       branchName: string
+      settings: RepositorySettingsSchema
     }) => {
       // close other flashes and dialogs when this is opened
       closeAllFlashes()
@@ -219,6 +222,7 @@ const Fork = () => {
         forkRepoName: forkData?.data?.name ?? '',
         forkRepoOwner: forkData?.data?.owner.login ?? '',
         forkId: String(forkData?.data?.id),
+        settings,
       })
         .then((res) => {
           if (res.success) {

--- a/src/app/components/dialog/CreateMirrorDialog.tsx
+++ b/src/app/components/dialog/CreateMirrorDialog.tsx
@@ -1,8 +1,19 @@
-import { Box, FormControl, Label, Link, Text, TextInput } from '@primer/react'
+import { zodResolver } from '@hookform/resolvers/zod'
+import {
+  Box,
+  Checkbox,
+  FormControl,
+  Label,
+  Link,
+  Select,
+  Text,
+  TextInput,
+} from '@primer/react'
 import { Stack } from '@primer/react/lib-esm/Stack'
 import { Dialog } from '@primer/react/lib-esm/drafts'
-
 import { useState } from 'react'
+import { useForm } from 'react-hook-form'
+import { RepositorySettingsSchema } from 'server/repos/schema'
 
 interface CreateMirrorDialogProps {
   orgLogin: string
@@ -10,7 +21,11 @@ interface CreateMirrorDialogProps {
   forkParentName: string
   isOpen: boolean
   closeDialog: () => void
-  createMirror: (data: { repoName: string; branchName: string }) => void
+  createMirror: (data: {
+    repoName: string
+    branchName: string
+    settings: RepositorySettingsSchema
+  }) => void
 }
 
 export const CreateMirrorDialog = ({
@@ -23,6 +38,9 @@ export const CreateMirrorDialog = ({
 }: CreateMirrorDialogProps) => {
   // set to default value of 'repository-name' for display purposes
   const [repoName, setRepoName] = useState('repository-name')
+  const { register, watch, getValues } = useForm<RepositorySettingsSchema>({
+    resolver: zodResolver(RepositorySettingsSchema),
+  })
 
   if (!isOpen) {
     return null
@@ -44,7 +62,11 @@ export const CreateMirrorDialog = ({
           content: 'Confirm',
           variant: 'primary',
           onClick: () => {
-            createMirror({ repoName, branchName: repoName })
+            createMirror({
+              repoName,
+              branchName: repoName,
+              settings: getValues(),
+            })
             setRepoName('repository-name')
           },
           disabled: repoName === 'repository-name' || repoName === '',
@@ -76,7 +98,7 @@ export const CreateMirrorDialog = ({
             </Link>
           </FormControl.Caption>
         </FormControl>
-        <FormControl>
+        <FormControl sx={{ marginBottom: '10px' }}>
           <FormControl.Label>Mirror location</FormControl.Label>
           <Box
             sx={{
@@ -122,6 +144,52 @@ export const CreateMirrorDialog = ({
                 </Stack.Item>
               </Stack.Item>
             </Stack>
+          </Box>
+        </FormControl>
+        <FormControl>
+          <FormControl.Label>Mirror Settings</FormControl.Label>
+          <Box
+            sx={{
+              padding: '15px',
+              border: '1px solid',
+              borderColor: 'border.default',
+              borderRadius: '6px',
+              width: '100%',
+            }}
+          >
+            <FormControl
+              sx={{
+                marginBottom: '10px',
+              }}
+            >
+              <Checkbox {...register('actions.enabled')} />
+              <FormControl.Label>Enable Actions</FormControl.Label>
+            </FormControl>
+            <FormControl
+              sx={{
+                width: '100%',
+              }}
+              disabled={!watch().actions?.enabled}
+            >
+              <FormControl.Label>Allowed Actions Settings</FormControl.Label>
+              <Select
+                sx={{
+                  width: '100%',
+                }}
+                {...register('actions.allowedActions')}
+              >
+                <Select.Option value="all">
+                  Allow all actions and reusable workflows
+                </Select.Option>
+                <Select.Option value="local_only">
+                  Allow enterprise actions and reusable workflows
+                </Select.Option>
+                <Select.Option value="selected">
+                  Allow enterprise, and select non-enterprise, actions and
+                  reusable workflows
+                </Select.Option>
+              </Select>
+            </FormControl>
           </Box>
         </FormControl>
       </Box>

--- a/src/server/repos/schema.ts
+++ b/src/server/repos/schema.ts
@@ -1,5 +1,12 @@
 import { z } from 'zod'
 
+export const RepositorySettingsSchema = z.object({
+  actions: z.object({
+    enabled: z.boolean(),
+    allowedActions: z.enum(['all', 'local_only', 'selected']).optional(),
+  }),
+})
+
 export const CreateMirrorSchema = z.object({
   orgId: z.string(),
   forkRepoOwner: z.string(),
@@ -7,6 +14,7 @@ export const CreateMirrorSchema = z.object({
   forkId: z.string(),
   newRepoName: z.string().max(100),
   newBranchName: z.string(),
+  settings: RepositorySettingsSchema,
 })
 
 export const ListMirrorsSchema = z.object({
@@ -29,3 +37,4 @@ export type CreateMirrorSchema = z.TypeOf<typeof CreateMirrorSchema>
 export type ListMirrorsSchema = z.TypeOf<typeof ListMirrorsSchema>
 export type EditMirrorSchema = z.TypeOf<typeof EditMirrorSchema>
 export type DeleteMirrorSchema = z.TypeOf<typeof DeleteMirrorSchema>
+export type RepositorySettingsSchema = z.TypeOf<typeof RepositorySettingsSchema>

--- a/test/octomock/index.ts
+++ b/test/octomock/index.ts
@@ -1,6 +1,7 @@
 // This is taken from https://github.com/Chocrates/octomock
 
 let mockFunctions = {
+  request: jest.fn(),
   config: {
     get: jest.fn(),
   },
@@ -306,6 +307,7 @@ export class Octomock {
   mockFunctions: {
     rest: Record<string, Record<string, jest.Mock>>
     config: Record<string, jest.Mock>
+    request: jest.Mock
   }
   defaultContext: { payload: { issue: { body: string; user: {} } } }
 


### PR DESCRIPTION

# Pull Request

<!--
PR title needs to be prefixed with a conventional commit type
(build,chore,ci,docs,feat,fix,perf,refactor,revert,style,test)

It should also be brief and descriptive for a good changelog entry

examples: "feat: add new logger" or "fix: remove unused imports"
-->

## Proposed Changes

<!-- Describe what the changes are and link to a GitHub Issue if one exists -->

This adds the ability to disable actions all together from the mirror creation page. It also always users to specify what types of actions are allowed to run.

I'm sure something will break if an organization disallows different types of actions settings. 

We'll also need a way to force app owners to enable disable setting these settings. 

https://github.com/user-attachments/assets/1d45a621-17c8-40ba-b37c-fbd6b50410cb


## Readiness Checklist

### Author/Contributor

- [ ] If documentation is needed for this change, has that been included in this pull request
- [ ] run `npm run lint` and fix any linting issues that have been introduced
- [ ] run `npm run test` and run tests
- [ ] If publishing new data to the public (scorecards, security scan results, code quality results, live dashboards, etc.), please request review from `@jeffrey-luszcz`

### Reviewer

- [ ] Label as either `bug`, `documentation`, `enhancement`, `infrastructure`, `maintenance`, or `breaking`
