### PR TITLE
feat: Add GitHub Action to push Docker image to GitHub Container Registry

### DIFF
--- a/.github/workflows/push-docker-image.yml
+++ b/.github/workflows/push-docker-image.yml
@@ -1,0 +1,22 @@
+name: Push Docker Image
+
+on:
+  push:
+    branches:
+      - main
+  release:
+    types: [ published ]
+
+jobs:
+  push-docker-image:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Push to GHCR
+        uses: macbr/push-to-ghcr@v14
+        with:
+          image_name: ${{ github.repository }}
+          github_token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/push-docker-image.yml
+++ b/.github/workflows/push-docker-image.yml
@@ -5,7 +5,7 @@ on:
     branches:
       - main
   release:
-    types: [ published ]
+    types: [published]
 
 jobs:
   push-docker-image:

--- a/README.md
+++ b/README.md
@@ -101,6 +101,20 @@ The authentication of the UI will still need to be a user's github.com user, but
 
 Once the app is installed, follow this document on [Using the Private Mirrors App](docs/using-the-app.md) to get the repository fork and mirrors set up for work.
 
+## Pulling the Docker Container from GitHub Container Registry
+
+You can pull the Docker container for this project from GitHub Container Registry and use it on a containerized PaaS like Azure. The Docker container is available at the following URL:
+
+```
+ghcr.io/github-community-projects/private-mirrors:latest
+```
+
+Tagged versions are available as well, for example:
+
+```
+ghcr.io/github-community-projects/private-mirrors:0.20.0
+```
+
 ## Developing
 
 ### Environment


### PR DESCRIPTION
This uses the `macbre/push-to-ghcr` Action to build and push on commits to main or numbered releases.

One open question, I'm not sure if this should be folded into the existing `build-docker.yml` workflow or if that's referenced/used separately.

Addresses #239 

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/github-community-projects/private-mirrors?shareId=20d83924-e338-4a1a-974e-cede787218bf).