### PR TITLE
build: added syncingore to skip the specific paths in the private mirror (e.g. sensitive data or tests) 

### DIFF
--- a/.syncignore
+++ b/.syncignore
@@ -1,0 +1,4 @@
+# .syncignore
+node_modules/
+dist/
+*.log

--- a/test/server/git.controller.test.ts
+++ b/test/server/git.controller.test.ts
@@ -1,0 +1,49 @@
+import { fetchExclusionConfig } from '../../src/server/git/controller'
+import fs from 'fs'
+import path from 'path'
+
+jest.mock('fs')
+jest.mock('path')
+
+describe('fetchExclusionConfig', () => {
+  const repoPath = '/fake/repo/path'
+  const configPath = '/fake/repo/path/.syncignore'
+
+  beforeEach(() => {
+    jest.resetAllMocks()
+  })
+
+  it('should return exclusion paths when .syncignore file exists', async () => {
+    const mockContent = 'path/to/exclude1\npath/to/exclude2\n'
+    jest.spyOn(fs, 'existsSync').mockReturnValue(true)
+    jest.spyOn(fs, 'readFileSync').mockReturnValue(mockContent)
+    jest.spyOn(path, 'join').mockReturnValue(configPath)
+
+    const result = await fetchExclusionConfig(repoPath)
+    expect(result).toEqual(['path/to/exclude1', 'path/to/exclude2'])
+    expect(fs.existsSync).toHaveBeenCalledWith(configPath)
+    expect(fs.readFileSync).toHaveBeenCalledWith(configPath, 'utf-8')
+  })
+
+  it('should return an empty array when .syncignore file does not exist', async () => {
+    jest.spyOn(fs, 'existsSync').mockReturnValue(false)
+    jest.spyOn(path, 'join').mockReturnValue(configPath)
+
+    const result = await fetchExclusionConfig(repoPath)
+    expect(result).toEqual([])
+    expect(fs.existsSync).toHaveBeenCalledWith(configPath)
+    expect(fs.readFileSync).not.toHaveBeenCalled()
+  })
+
+  it('should return an empty array when .syncignore file is empty', async () => {
+    const mockContent = ''
+    jest.spyOn(fs, 'existsSync').mockReturnValue(true)
+    jest.spyOn(fs, 'readFileSync').mockReturnValue(mockContent)
+    jest.spyOn(path, 'join').mockReturnValue(configPath)
+
+    const result = await fetchExclusionConfig(repoPath)
+    expect(result).toEqual([])
+    expect(fs.existsSync).toHaveBeenCalledWith(configPath)
+    expect(fs.readFileSync).toHaveBeenCalledWith(configPath, 'utf-8')
+  })
+})


### PR DESCRIPTION
# Pull Request

build: added syncingore to skip the specific paths in the private mirror (e.g. sensitive data or tests) 

## Proposed Changes

N/A

## Readiness Checklist

### Author/Contributor

- [ ] If documentation is needed for this change, has that been included in this pull request
- [ ] run `npm run lint` and fix any linting issues that have been introduced
- [ ] run `npm run test` and run tests
- [ ] If publishing new data to the public (scorecards, security scan results, code quality results, live dashboards, etc.), please request review from `@jeffrey-luszcz`

### Reviewer

- [ enhancement] 
