### PR TITLE
feat: Enable mirroring non-forked repos

### DIFF
--- a/env.mjs
+++ b/env.mjs
@@ -19,6 +19,7 @@ export const env = createEnv({
     // Optional environment variables
     LOGGING_LEVEL: z.string().optional().default('debug'),
     NODE_ENV: z.string().optional().default('development'),
+    FORKS_ONLY: z.string().optional().default('true'),
     PUBLIC_ORG: z.string().optional(),
     PRIVATE_ORG: z.string().optional(),
     // Custom validation for a comma separated list of strings
@@ -62,6 +63,7 @@ export const env = createEnv({
     PRIVATE_KEY: process.env.PRIVATE_KEY,
     LOGGING_LEVEL: process.env.LOGGING_LEVEL,
     NODE_ENV: process.env.NODE_ENV,
+    FORKS_ONLY: process.env.FORKS_ONLY,
     PUBLIC_ORG: process.env.PUBLIC_ORG,
     PRIVATE_ORG: process.env.PRIVATE_ORG,
     ALLOWED_HANDLES: process.env.ALLOWED_HANDLES,

--- a/src/hooks/useForks.tsx
+++ b/src/hooks/useForks.tsx
@@ -8,12 +8,18 @@ import { logger } from '../utils/logger'
 
 const forksLogger = logger.getSubLogger({ name: 'useForks' })
 
+interface QueryVariables {
+  login: string
+  isFork?: boolean
+}
+
 const getForksInOrg = async (accessToken: string, login: string) => {
+  const queryVariables: QueryVariables = { login }
+  if (process.env.FORKS_ONLY === 'true') {
+    queryVariables.isFork = true
+  }
   const res = await personalOctokit(accessToken)
-    .graphql.paginate<ForksObject>(getReposInOrgGQL, {
-      login,
-      isFork: true,
-    })
+    .graphql.paginate<ForksObject>(getReposInOrgGQL, queryVariables)
     .catch((error: Error & { data: ForksObject }) => {
       forksLogger.error('Error fetching forks', { error })
       return error.data


### PR DESCRIPTION
This is a pretty simplistic change to add the ability to mirror repos which are not actually forks of upstream projects. This is useful for demos and testing but it also can be helpful if the public organization actually *is* the upstream, because the repo contains a project we own, so we're the top of the fork network.

Addresses #251

## Readiness Checklist

### Author/Contributor

- [ ] If documentation is needed for this change, has that been included in this pull request
- [x] run `npm run lint` and fix any linting issues that have been introduced
- [x] run `npm run test` and run tests
- [ ] If publishing new data to the public (scorecards, security scan results, code quality results, live dashboards, etc.), please request review from `@jeffrey-luszcz`

### Reviewer

- [ ] Label as either `bug`, `documentation`, `enhancement`, `infrastructure`, `maintenance`, or `breaking`
