### PR TITLE
chore: fix version comment for codeql action

### DIFF
--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -42,6 +42,6 @@ jobs:
           path: results.sarif
           retention-days: 5
       - name: 'Upload to code-scanning'
-        uses: github/codeql-action/upload-sarif@ea9e4e37992a54ee68a9622e985e60c8e8f12d9f # v3.24.9
+        uses: github/codeql-action/upload-sarif@ea9e4e37992a54ee68a9622e985e60c8e8f12d9f # v3.27.4
         with:
           sarif_file: results.sarif


### PR DESCRIPTION
# Pull Request

## Proposed Changes

Fix the version number in the comment for the `github/codeql-action/upload-sarif` GitHub Action. See https://github.com/github-community-projects/private-mirrors/pull/269 where this was not bumped properly and https://github.com/github-community-projects/private-mirrors/pull/269#issuecomment-2495557174 for a potential reason (the version in the comment being out of date). Hopefully this will fix the dependabot updates going forward to properly update the comment.

## Readiness Checklist

### Author/Contributor

- [x] ~~If documentation is needed for this change, has that been included in this pull request~~
- [x] ~~run `npm run lint` and fix any linting issues that have been introduced~~
- [x] ~~run `npm run test` and run tests~~
- [x] ~~If publishing new data to the public (scorecards, security scan results, code quality results, live dashboards, etc.), please request review from `@jeffrey-luszcz`~~

### Reviewer

- [x] Label as either `bug`, `documentation`, `enhancement`, `infrastructure`, `maintenance`, or `breaking`
