### PR TITLE
fix: create mirror error handling overwriting initial error

### DIFF
--- a/test/server/repos.test.ts
+++ b/test/server/repos.test.ts
@@ -199,9 +199,18 @@ describe('Repos router', () => {
     om.mockFunctions.rest.orgs.get.mockResolvedValue(fakeOrg)
     om.mockFunctions.rest.repos.get.mockResolvedValueOnce(repoNotFound)
     om.mockFunctions.rest.repos.get.mockResolvedValueOnce(fakeMirrorRepo)
-    om.mockFunctions.rest.repos.delete.mockResolvedValue({})
+    stubbedGit.clone.mockResolvedValue({})
+    om.mockFunctions.rest.orgs.getAllCustomProperties.mockResolvedValue({
+      data: [{ fork: 'test' }],
+    })
+    om.mockFunctions.rest.repos.createInOrg.mockResolvedValue({
+      data: { owner: { login: 'github' } },
+    })
 
-    stubbedGit.clone.mockRejectedValue(new Error('clone error'))
+    // error after repo creation so that cleanup can be tested
+    stubbedGit.addRemote.mockRejectedValue(new Error('error adding remote'))
+
+    om.mockFunctions.rest.repos.delete.mockResolvedValue({})
 
     await caller
       .createMirror({
@@ -213,7 +222,7 @@ describe('Repos router', () => {
         newRepoName: 'test',
       })
       .catch((error) => {
-        expect(error.message).toEqual('clone error')
+        expect(error.message).toEqual('error adding remote')
       })
 
     expect(configSpy).toHaveBeenCalledTimes(1)
@@ -239,9 +248,19 @@ describe('Repos router', () => {
     om.mockFunctions.rest.orgs.get.mockResolvedValue(fakeOrg)
     om.mockFunctions.rest.repos.get.mockResolvedValueOnce(repoNotFound)
     om.mockFunctions.rest.repos.get.mockResolvedValueOnce(fakeMirrorRepo)
+    stubbedGit.clone.mockResolvedValue({})
+    om.mockFunctions.rest.orgs.getAllCustomProperties.mockResolvedValue({
+      data: [{ fork: 'test' }],
+    })
+    om.mockFunctions.rest.repos.createInOrg.mockResolvedValue({
+      data: { owner: { login: 'github-test' } },
+    })
     om.mockFunctions.rest.repos.delete.mockResolvedValue({})
 
-    stubbedGit.clone.mockRejectedValue(new Error('clone error'))
+    // error after repo creation so that cleanup can be tested
+    stubbedGit.addRemote.mockRejectedValue(new Error('error adding remote'))
+
+    om.mockFunctions.rest.repos.delete.mockResolvedValue({})
 
     await caller
       .createMirror({
@@ -253,7 +272,7 @@ describe('Repos router', () => {
         newRepoName: 'test',
       })
       .catch((error) => {
-        expect(error.message).toEqual('clone error')
+        expect(error.message).toEqual('error adding remote')
       })
 
     expect(configSpy).toHaveBeenCalledTimes(1)


### PR DESCRIPTION
# Pull Request

<!--
PR title needs to be prefixed with a conventional commit type
(build,chore,ci,docs,feat,fix,perf,refactor,revert,style,test)

It should also be brief and descriptive for a good changelog entry

examples: "feat: add new logger" or "fix: remove unused imports"
-->

## Proposed Changes

<!-- Describe what the changes are and link to a GitHub Issue if one exists -->

Replaces the current nested error handling with an if inside the outer error handler that checks if the mirror repo has already been created before attempting to delete it on failure.

## Readiness Checklist

### Author/Contributor

- [ ] If documentation is needed for this change, has that been included in this pull request
- [ ] run `npm run lint` and fix any linting issues that have been introduced
- [ ] run `npm run test` and run tests
- [ ] If publishing new data to the public (scorecards, security scan results, code quality results, live dashboards, etc.), please request review from `@jeffrey-luszcz`

### Reviewer

- [ ] Label as either `bug`, `documentation`, `enhancement`, `infrastructure`, `maintenance`, or `breaking`
