### PR TITLE
feat: start using github/ospo-reusable-workflows

### DIFF
--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -32,14 +32,18 @@ version-resolver:
   major:
     labels:
       - 'breaking'
+      - 'major'
   minor:
     labels:
       - 'enhancement'
-      - 'fix'
+      - 'feature'
+      - 'minor'
   patch:
     labels:
+      - 'fix'
       - 'documentation'
       - 'maintenance'
+      - 'patch'
   default: patch
 autolabeler:
   - label: 'automation'

--- a/.github/workflows/auto-labeler.yml
+++ b/.github/workflows/auto-labeler.yml
@@ -14,11 +14,8 @@ jobs:
     permissions:
       contents: write
       pull-requests: write
-    name: Auto label pull requests
-    runs-on: ubuntu-latest
-    steps:
-      - uses: release-drafter/release-drafter@3f0f87098bd6b5c5b9a36d49c41d998ea58f9348 # pin@v6
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        with:
-          config-name: release-drafter.yml
+    uses: github/ospo-reusable-workflows/.github/workflows/auto-labeler.yaml@1406afbf7a795f706f04644059cecbb3b2f0c1a0
+    with:
+      config-name: release-drafter.yml
+    secrets:
+      github-token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/pr-title.yml
+++ b/.github/workflows/pr-title.yml
@@ -6,6 +6,7 @@ on:
   pull_request_target:
     types:
       - opened
+      - reopened
       - edited
       - synchronize
 
@@ -15,27 +16,9 @@ permissions:
 jobs:
   main:
     permissions:
+      contents: read
       pull-requests: read
       statuses: write
-    name: Validate PR title
-    runs-on: ubuntu-latest
-    steps:
-      - uses: amannn/action-semantic-pull-request@40166f00814508ec3201fc8595b393d451c8cd80 # pin@v5
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        with:
-          # Configure which types are allowed (newline-delimited).
-          # From: https://github.com/commitizen/conventional-commit-types/blob/master/index.json
-          # listing all below
-          types: |
-            build
-            chore
-            ci
-            docs
-            feat
-            fix
-            perf
-            refactor
-            revert
-            style
-            test
+    uses: github/ospo-reusable-workflows/.github/workflows/pr-title.yaml@1406afbf7a795f706f04644059cecbb3b2f0c1a0
+    secrets:
+      github-token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,26 +13,30 @@ permissions:
   contents: read
 
 jobs:
-  create_release:
-    # release if
-    # manual deployment OR
-    # merged to main and labelled with release labels
-    if: |
-      (github.event_name == 'workflow_dispatch') ||
-      (github.event.pull_request.merged == true &&
-      (contains(github.event.pull_request.labels.*.name, 'breaking') ||
-      contains(github.event.pull_request.labels.*.name, 'feature') ||
-      contains(github.event.pull_request.labels.*.name, 'vuln') ||
-      contains(github.event.pull_request.labels.*.name, 'release')))
-    runs-on: ubuntu-latest
+  release:
     permissions:
       contents: write
       pull-requests: read
-    steps:
-      - uses: release-drafter/release-drafter@3f0f87098bd6b5c5b9a36d49c41d998ea58f9348 # pin@v6
-        id: release-drafter
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        with:
-          config-name: release-drafter.yml
-          publish: true
+    uses: github/ospo-reusable-workflows/.github/workflows/release.yaml@53a9c808122ffaae9af948f72139fb4bd44ab74c
+    with:
+      publish: true
+      release-config-name: release-drafter.yml
+    secrets:
+      github-token: ${{ secrets.GITHUB_TOKEN }}
+  release_image:
+    needs: release
+    permissions:
+      contents: write
+      discussions: write
+      packages: write
+      pull-requests: read
+    uses: github/ospo-reusable-workflows/.github/workflows/release-image.yaml@53a9c808122ffaae9af948f72139fb4bd44ab74c
+    with:
+      image-name: ${{ github.repository }}
+      full-tag: ${{ needs.release.outputs.full-tag }}
+      short-tag: ${{ needs.release.outputs.short-tag }}
+    secrets:
+      github-token: ${{ secrets.GITHUB_TOKEN }}
+      image-registry: ghcr.io
+      image-registry-username: ${{ github.actor }}
+      image-registry-password: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
# Pull Request

<!--
PR title needs to be prefixed with a conventional commit type
(build,chore,ci,docs,feat,fix,perf,refactor,revert,style,test)

It should also be brief and descriptive for a good changelog entry

examples: "feat: add new logger" or "fix: remove unused imports"
-->

## Proposed Changes

- [x] start using the ospo-reusable-workflows for auto-labeler, pr-title, release and release-image
- [x] move 'fix' to patch semver, add 'feature' to minor semver, add major/minor/patch labels to semver
- [x] add release-image part to release workflow
  - will generate a release image called privoate-mirrors in ghcr.io with release tag and latest tag
  - might replace https://github.com/github-community-projects/private-mirrors/pull/238 (digest work there can be added)

## Readiness Checklist

### Author/Contributor

- [ ] If documentation is needed for this change, has that been included in this pull request
- [ ] run `npm run lint` and fix any linting issues that have been introduced
- [ ] run `npm run test` and run tests
- [ ] If publishing new data to the public (scorecards, security scan results, code quality results, live dashboards, etc.), please request review from `@jeffrey-luszcz`

### Reviewer

- [x] Label as either `bug`, `documentation`, `enhancement`, `infrastructure`, `maintenance`, or `breaking`
