### PR TITLE
chore: update workflows

### DIFF
--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -5,7 +5,7 @@ template: |
   # Changelog
   $CHANGES
 
-  See details of [all code changes](https://github.com/github-community-projects/private-mirrors/compare/$PREVIOUS_TAG...v$RESOLVED_VERSION) since previous release
+  See details of [all code changes](https://github.com/$OWNER/$REPOSITORY/compare/$PREVIOUS_TAG...v$RESOLVED_VERSION) since previous release
 
 categories:
   - title: '🚀 Features'

--- a/.github/workflows/auto-labeler.yml
+++ b/.github/workflows/auto-labeler.yml
@@ -12,9 +12,9 @@ permissions:
 jobs:
   main:
     permissions:
-      contents: write
+      contents: read
       pull-requests: write
-    uses: github/ospo-reusable-workflows/.github/workflows/auto-labeler.yaml@1406afbf7a795f706f04644059cecbb3b2f0c1a0
+    uses: github/ospo-reusable-workflows/.github/workflows/auto-labeler.yaml@6a0a6d0de2227f9d5d11af90a87b2e2fd6b5463d
     with:
       config-name: release-drafter.yml
     secrets:

--- a/.github/workflows/pr-title.yml
+++ b/.github/workflows/pr-title.yml
@@ -19,6 +19,6 @@ jobs:
       contents: read
       pull-requests: read
       statuses: write
-    uses: github/ospo-reusable-workflows/.github/workflows/pr-title.yaml@1406afbf7a795f706f04644059cecbb3b2f0c1a0
+    uses: github/ospo-reusable-workflows/.github/workflows/pr-title.yaml@6a0a6d0de2227f9d5d11af90a87b2e2fd6b5463d
     secrets:
       github-token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,7 +17,7 @@ jobs:
     permissions:
       contents: write
       pull-requests: read
-    uses: github/ospo-reusable-workflows/.github/workflows/release.yaml@53a9c808122ffaae9af948f72139fb4bd44ab74c
+    uses: github/ospo-reusable-workflows/.github/workflows/release.yaml@6a0a6d0de2227f9d5d11af90a87b2e2fd6b5463d
     with:
       publish: true
       release-config-name: release-drafter.yml
@@ -26,15 +26,16 @@ jobs:
   release_image:
     needs: release
     permissions:
-      contents: write
-      discussions: write
+      contents: read
       packages: write
-      pull-requests: read
-    uses: github/ospo-reusable-workflows/.github/workflows/release-image.yaml@53a9c808122ffaae9af948f72139fb4bd44ab74c
+      id-token: write
+      attestations: write
+    uses: github/ospo-reusable-workflows/.github/workflows/release-image.yaml@6a0a6d0de2227f9d5d11af90a87b2e2fd6b5463d
     with:
       image-name: ${{ github.repository }}
       full-tag: ${{ needs.release.outputs.full-tag }}
       short-tag: ${{ needs.release.outputs.short-tag }}
+      create-attestation: true
     secrets:
       github-token: ${{ secrets.GITHUB_TOKEN }}
       image-registry: ghcr.io


### PR DESCRIPTION
# Pull Request

## Proposed Changes

- [x] update ospo-reusable-workflows version
  - prevents auto-labeler creating draft releases
- [x] update permissions on release-image, allows for attestations, if enabled
- [x] update release-drafter template with more generalized owner and repo names
- [x] enable attestations for the release image created

## Readiness Checklist

### Author/Contributor

- [ ] If documentation is needed for this change, has that been included in this pull request
- [ ] run `npm run lint` and fix any linting issues that have been introduced
- [ ] run `npm run test` and run tests
- [ ] If publishing new data to the public (scorecards, security scan results, code quality results, live dashboards, etc.), please request review from `@jeffrey-luszcz`

### Reviewer

- [x] Label as either `bug`, `documentation`, `enhancement`, `infrastructure`, `maintenance`, or `breaking`
