### PR TITLE
feat: add skip branch protection creation variable

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -27,3 +27,6 @@ NODE_ENV=development
 # Used for GHEC configs, where private mirrors are kept in a different org
 PUBLIC_ORG=
 PRIVATE_ORG=
+
+# Used to skip branch protection creation if organization level branch protections are used instead
+SKIP_BRANCH_PROTECTION_CREATION=

--- a/env.mjs
+++ b/env.mjs
@@ -39,6 +39,11 @@ export const env = createEnv({
         if (val === '') return true
         return val.split(',').every((org) => org.trim().length > 0)
       }, 'Invalid comma separated list of GitHub orgs'),
+    SKIP_BRANCH_PROTECTION_CREATION: z
+      .enum(['true', 'false', ''])
+      .optional()
+      .default('false')
+      .transform((value) => value === 'true'),
   },
   /*
    * Environment variables available on the client (and server).
@@ -66,6 +71,8 @@ export const env = createEnv({
     PRIVATE_ORG: process.env.PRIVATE_ORG,
     ALLOWED_HANDLES: process.env.ALLOWED_HANDLES,
     ALLOWED_ORGS: process.env.ALLOWED_ORGS,
+    SKIP_BRANCH_PROTECTION_CREATION:
+      process.env.SKIP_BRANCH_PROTECTION_CREATION,
   },
   skipValidation: process.env.SKIP_ENV_VALIDATIONS === 'true',
 })

--- a/src/bot/index.ts
+++ b/src/bot/index.ts
@@ -91,6 +91,8 @@ function bot(app: Probot) {
       return
     }
 
+    if (process.env.SKIP_BRANCH_PROTECTION_CREATION) return
+
     try {
       // Get the default branch
       const defaultBranch = context.payload.repository.default_branch
@@ -148,6 +150,8 @@ function bot(app: Probot) {
       botLogger.info('Not a mirror repo, skipping')
       return
     }
+
+    if (process.env.SKIP_BRANCH_PROTECTION_CREATION) return
 
     try {
       // Get the default branch
@@ -249,6 +253,8 @@ function bot(app: Probot) {
     } catch (error) {
       botLogger.error('Failed to sync repository', { error })
     }
+
+    if (process.env.SKIP_BRANCH_PROTECTION_CREATION) return
 
     try {
       // Get the default branch

--- a/src/bot/rules.ts
+++ b/src/bot/rules.ts
@@ -25,6 +25,8 @@ export const createAllPushProtection = async (
   repositoryNodeId: string,
   actorNodeId: string,
 ) => {
+  if (process.env.SKIP_BRANCH_PROTECTION_CREATION) return // don't add branch protections if the env is set to skip
+
   rulesLogger.info('Creating branch protection for all branches', {
     repositoryOwner: context.payload.repository.owner.login,
     repositoryName: context.payload.repository.name,
@@ -86,6 +88,8 @@ export const createDefaultBranchProtection = async (
   actorNodeId: string,
   defaultBranch: string,
 ) => {
+  if (process.env.SKIP_BRANCH_PROTECTION_CREATION) return // fallback protection in case the env is not checked before calling this function
+
   rulesLogger.info('Creating branch protection for default branch', {
     repositoryOwner: context.payload.repository.owner.login,
     repositoryName: context.payload.repository.name,


### PR DESCRIPTION
# Pull Request

<!--
PR title needs to be prefixed with a conventional commit type
(build,chore,ci,docs,feat,fix,perf,refactor,revert,style,test)

It should also be brief and descriptive for a good changelog entry

examples: "feat: add new logger" or "fix: remove unused imports"
-->

## Proposed Changes

<!-- Describe what the changes are and link to a GitHub Issue if one exists -->

This change adds an environment variable (SKIP_BRANCH_PROTECTION_CREATION) that can be used to disable private-mirrors' default branch protection creation. This is useful for deployments that seek to make use of customized organization-level branch protections rather than private-mirrors' built-in configuration as otherwise the branch protections may conflict.

Side note: this PR was made through Capital One's private-mirrors deployment 🥳 

## Readiness Checklist

### Author/Contributor

- [x] If documentation is needed for this change, has that been included in this pull request
- [x] run `npm run lint` and fix any linting issues that have been introduced
- [x] run `npm run test` and run tests
- [ ] If publishing new data to the public (scorecards, security scan results, code quality results, live dashboards, etc.), please request review from `@jeffrey-luszcz`

### Reviewer

- [ ] Label as either `bug`, `documentation`, `enhancement`, `infrastructure`, `maintenance`, or `breaking`
