### PR TITLE
chore: specify supported lts node.js versions

### DIFF
--- a/docs/developing.md
+++ b/docs/developing.md
@@ -2,8 +2,8 @@
 
 ## Prerequisites
 
-- Node.js (version 18 or higher)
-- npm (version 6 or higher)
+- Node.js (LTS versions, 18 or higher with 22 preferred)
+- npm (version 10 or higher)
 - Docker (optional, for running the app in a container)
 
 ## Getting Started

--- a/package-lock.json
+++ b/package-lock.json
@@ -61,7 +61,7 @@
         "typescript-eslint": "7.16.1"
       },
       "engines": {
-        "node": ">= 18"
+        "node": "18 || 20 || 22"
       }
     },
     "node_modules/@aashutoshrathi/word-wrap": {

--- a/package.json
+++ b/package.json
@@ -78,6 +78,18 @@
   "engines": {
     "node": "18 || 20 || 22"
   },
+  "devEngines": {
+    "runtime": {
+      "name": "node",
+      "version": "18 || 20 || 22",
+      "onFail": "warn"
+    },
+    "packageManager": {
+      "name": "npm",
+      "version": "10 || 11",
+      "onFail": "warn"
+    }
+  },
   "lint-staged": {
     "*": "npm run lint:fix"
   }

--- a/package.json
+++ b/package.json
@@ -76,7 +76,7 @@
     }
   },
   "engines": {
-    "node": ">= 18"
+    "node": "18 || 20 || 22"
   },
   "lint-staged": {
     "*": "npm run lint:fix"


### PR DESCRIPTION
# Pull Request

## Proposed Changes

Closes https://github.com/github-community-projects/private-mirrors/issues/334.
- Only officially support LTS Node.js versions.
- Drop support for non-LTS versions greater than 18. Before non-LTS versions >18 that are EOL were allowed with the engines defined.
- List supported Node.js and npm versions for development. I kept these flexible to support the npm version bundled with Node.js and the latest version, and the supported Node.js versions. We could choose to only support Node.js 22 for development.

## Readiness Checklist

### Author/Contributor

- [x] If documentation is needed for this change, has that been included in this pull request
- [x] run `npm run lint` and fix any linting issues that have been introduced
- [x] run `npm run test` and run tests
- [x] ~~If publishing new data to the public (scorecards, security scan results, code quality results, live dashboards, etc.), please request review from `@jeffrey-luszcz`~~

### Reviewer

- [x] Label as either `bug`, `documentation`, `enhancement`, `infrastructure`, `maintenance`, or `breaking`
