### PR TITLE
feat: add base64 encoded private key support

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -3,7 +3,7 @@ APP_ID=12345
 GITHUB_CLIENT_ID=Iv1.12345def
 GITHUB_CLIENT_SECRET=clientsecret
 
-# Private key for the GitHub App
+# Private key for the GitHub App (base64 encoded or raw)
 PRIVATE_KEY=-----BEGIN RSA PRIVATE KEY-----\nYOUR KEY HERE WITH \n INCLUDED=\n-----END RSA PRIVATE KEY-----\n
 
 # Auth configs

--- a/docs/developing.md
+++ b/docs/developing.md
@@ -83,7 +83,7 @@ To use the app, you'll need to create a GitHub App and configure it to point to 
    - **Workflow run**
 
 7. Click **Create GitHub App**.
-8. Generate a private key for the app and add it to your `.env` file as `PRIVATE_KEY`.
+8. Generate a private key for the app and add it to your `.env` file as `PRIVATE_KEY`, a base64 encoded version can be used if desired.
 9. Note the **App ID** and **Client ID** and add them to your `.env` file as `APP_ID` and `GITHUB_CLIENT_ID`, respectively.
 10. Generate a new **Client Secret** and add it to your `.env` file as `GITHUB_CLIENT_SECRET`.
 

--- a/scripts/webhook-relay.mjs
+++ b/scripts/webhook-relay.mjs
@@ -14,12 +14,13 @@ if (!process.env.PUBLIC_ORG) {
 
 const url = `${process.env.NEXTAUTH_URL}/api/webhooks`
 
-// Support optional base64 decoding of the private key to prevent issues with complicated environment variable passing scenarios
-const privateKey = process.env.PRIVATE_KEY?.includes(
-  '-----BEGIN RSA PRIVATE KEY-----',
-)
-  ? process.env.PRIVATE_KEY.replace(/\\n/g, '\n') // this is necessary due to a bug with multiline envs in docker - See https://github.com/moby/moby/issues/46773
-  : Buffer.from(process.env.PRIVATE_KEY, 'base64').toString('utf8')
+const privateKey =
+  process.env.PRIVATE_KEY &&
+  !process.env.PRIVATE_KEY.includes('-----BEGIN RSA PRIVATE KEY-----')
+    ? // Support optional base64 decoding of the private key to prevent issues with complicated environment variable passing scenarios
+      Buffer.from(process.env.PRIVATE_KEY, 'base64').toString('utf8')
+    : // Handle a bug with multiline envs in docker - See https://github.com/moby/moby/issues/46773
+      (process.env.PRIVATE_KEY?.replace(/\\n/g, '\n') ?? '')
 
 const privateKeyPkcs8 = crypto.createPrivateKey(privateKey).export({
   type: 'pkcs8',

--- a/scripts/webhook-relay.mjs
+++ b/scripts/webhook-relay.mjs
@@ -14,12 +14,17 @@ if (!process.env.PUBLIC_ORG) {
 
 const url = `${process.env.NEXTAUTH_URL}/api/webhooks`
 
-const privateKeyPkcs8 = crypto
-  .createPrivateKey(process.env.PRIVATE_KEY.replace(/\\n/g, '\n'))
-  .export({
-    type: 'pkcs8',
-    format: 'pem',
-  })
+// Support optional base64 decoding of the private key to prevent issues with complicated environment variable passing scenarios
+const privateKey = process.env.PRIVATE_KEY?.includes(
+  '-----BEGIN RSA PRIVATE KEY-----',
+)
+  ? process.env.PRIVATE_KEY.replace(/\\n/g, '\n') // this is necessary due to a bug with multiline envs in docker - See https://github.com/moby/moby/issues/46773
+  : Buffer.from(process.env.PRIVATE_KEY, 'base64').toString('utf8')
+
+const privateKeyPkcs8 = crypto.createPrivateKey(privateKey).export({
+  type: 'pkcs8',
+  format: 'pem',
+})
 
 const setupForwarder = (organizationOwner) => {
   const app = new App({

--- a/src/bot/octokit.ts
+++ b/src/bot/octokit.ts
@@ -6,11 +6,12 @@ import { Octokit } from './rest'
 const personalOctokitLogger = logger.getSubLogger({ name: 'personal-octokit' })
 const appOctokitLogger = logger.getSubLogger({ name: 'app-octokit' })
 
-// This is a bug with the way the private key is stored in the docker env
-// See https://github.com/moby/moby/issues/46773
-const privateKey = process.env.PRIVATE_KEY?.includes('\\n')
-  ? process.env.PRIVATE_KEY.replace(/\\n/g, '\n')
-  : process.env.PRIVATE_KEY!
+// Support optional base64 decoding of the private key to prevent issues with complicated environment variable passing scenarios
+const privateKey = process.env.PRIVATE_KEY?.includes(
+  '-----BEGIN RSA PRIVATE KEY-----',
+)
+  ? process.env.PRIVATE_KEY.replace(/\\n/g, '\n') // this is necessary due to a bug with multiline envs in docker - See https://github.com/moby/moby/issues/46773
+  : Buffer.from(process.env.PRIVATE_KEY!, 'base64').toString('utf8')
 
 /**
  * Generates an app access token for the app or an installation (if installationId is provided)

--- a/src/bot/octokit.ts
+++ b/src/bot/octokit.ts
@@ -6,12 +6,13 @@ import { Octokit } from './rest'
 const personalOctokitLogger = logger.getSubLogger({ name: 'personal-octokit' })
 const appOctokitLogger = logger.getSubLogger({ name: 'app-octokit' })
 
-// Support optional base64 decoding of the private key to prevent issues with complicated environment variable passing scenarios
-const privateKey = process.env.PRIVATE_KEY?.includes(
-  '-----BEGIN RSA PRIVATE KEY-----',
-)
-  ? process.env.PRIVATE_KEY.replace(/\\n/g, '\n') // this is necessary due to a bug with multiline envs in docker - See https://github.com/moby/moby/issues/46773
-  : Buffer.from(process.env.PRIVATE_KEY!, 'base64').toString('utf8')
+const privateKey =
+  process.env.PRIVATE_KEY &&
+  !process.env.PRIVATE_KEY.includes('-----BEGIN RSA PRIVATE KEY-----')
+    ? // Support optional base64 decoding of the private key to prevent issues with complicated environment variable passing scenarios
+      Buffer.from(process.env.PRIVATE_KEY, 'base64').toString('utf8')
+    : // Handle a bug with multiline envs in docker - See https://github.com/moby/moby/issues/46773
+      (process.env.PRIVATE_KEY?.replace(/\\n/g, '\n') ?? '')
 
 /**
  * Generates an app access token for the app or an installation (if installationId is provided)

--- a/test/app.test.ts
+++ b/test/app.test.ts
@@ -2,7 +2,6 @@ import nock from 'nock'
 
 // Requiring our app implementation
 import { Probot, ProbotOctokit } from 'probot'
-import * as app from '../src/bot'
 import { Octomock } from './octomock'
 
 // Requiring our fixtures
@@ -22,6 +21,10 @@ const privateKey = fs.readFileSync(
   path.join(__dirname, 'fixtures/mock-cert.pem'),
   'utf-8',
 )
+
+process.env.PRIVATE_KEY = privateKey
+
+import * as app from '../src/bot' // import app after setting up the environment variable
 
 describe('Webhooks events', () => {
   let probot: Probot

--- a/test/server/config.test.ts
+++ b/test/server/config.test.ts
@@ -1,3 +1,13 @@
+import fs from 'fs'
+import path from 'path'
+
+// load private key before importing the code that uses it
+
+process.env.PRIVATE_KEY = fs.readFileSync(
+  path.join(__dirname, '../fixtures/mock-cert.pem'),
+  'utf-8',
+)
+
 import * as config from '../../src/bot/config'
 import * as auth from '../../src/utils/auth'
 import configRouter from '../../src/server/config/router'


### PR DESCRIPTION
# Pull Request

<!--
PR title needs to be prefixed with a conventional commit type
(build,chore,ci,docs,feat,fix,perf,refactor,revert,style,test)

It should also be brief and descriptive for a good changelog entry

examples: "feat: add new logger" or "fix: remove unused imports"
-->

## Proposed Changes

<!-- Describe what the changes are and link to a GitHub Issue if one exists -->

This change adds support for a base64 encoded private key which helps to avoid issues with retrieving, setting, and passing around an environment variable value that contains newlines which may be required for some enterprise secret management strategies. The base64 parsing was made conditional to avoid breaking existing setups while allowing the option for those that might need it.

## Readiness Checklist

### Author/Contributor

- [x] If documentation is needed for this change, has that been included in this pull request
- [x] run `npm run lint` and fix any linting issues that have been introduced
- [x] run `npm run test` and run tests
- [ ] If publishing new data to the public (scorecards, security scan results, code quality results, live dashboards, etc.), please request review from `@jeffrey-luszcz`

### Reviewer

- [x] Label as either `bug`, `documentation`, `enhancement`, `infrastructure`, `maintenance`, or `breaking`
