### PR TITLE
feat: use rebase when syncing changes from mirror/main back to fork

### DIFF
--- a/src/server/git/controller.ts
+++ b/src/server/git/controller.ts
@@ -85,30 +85,29 @@ export const syncReposHandler = async ({
 
     if (input.destinationTo === 'fork') {
       await git.checkoutBranch(
-        input.forkBranchName,
-        `fork/${input.forkBranchName}`,
-      )
-      gitApiLogger.debug('Checked out branch', input.forkBranchName)
-      await git.mergeFromTo(
+        input.mirrorBranchName,
         `mirror/${input.mirrorBranchName}`,
-        input.forkBranchName,
       )
-      gitApiLogger.debug('Merged branches')
+      gitApiLogger.debug('Checked out branch', input.mirrorBranchName)
+      await git.rebase([`fork/${input.forkBranchName}`])
+      gitApiLogger.debug('Rebased mirror branch onto fork branch')
       gitApiLogger.debug('git status', await git.status())
-      await git.push('fork', input.forkBranchName)
+      await git.push(
+        'fork',
+        `${input.mirrorBranchName}:${input.forkBranchName}`,
+      )
+      gitApiLogger.debug(`Pushed to fork/${input.forkBranchName} remote`)
     } else {
       await git.checkoutBranch(
         input.mirrorBranchName,
         `mirror/${input.mirrorBranchName}`,
       )
       gitApiLogger.debug('Checked out branch', input.mirrorBranchName)
-      await git.mergeFromTo(
-        `fork/${input.forkBranchName}`,
-        input.mirrorBranchName,
-      )
-      gitApiLogger.debug('Merged branches')
+      await git.rebase([`fork/${input.forkBranchName}`])
+      gitApiLogger.debug('Rebased mirror branch onto fork branch')
       gitApiLogger.debug('git status', await git.status())
-      await git.push('mirror', input.mirrorBranchName)
+      await git.push(['--force'])
+      gitApiLogger.debug(`Pushed to mirror/${input.mirrorBranchName} remote`)
     }
 
     return {


### PR DESCRIPTION
# Pull Request

This PR changes the repo sync logic. Instead of using merge, it will now use rebase.

## Proposed Changes

https://github.com/github-community-projects/private-mirrors/issues/368 addresses the bugs that arise from using merges and the need for rebases.

## Readiness Checklist

### Author/Contributor

- [x] If documentation is needed for this change, has that been included in this pull request
- [x] run `npm run lint` and fix any linting issues that have been introduced
- [x] run `npm run test` and run tests
- [x] If publishing new data to the public (scorecards, security scan results, code quality results, live dashboards, etc.), please request review from `@jeffrey-luszcz`

### Reviewer

- [x] Label as either `bug`, `documentation`, `enhancement`, `infrastructure`, `maintenance`, or `breaking`
