### PR TITLE
fix: issue with skipping bot pushes

### DIFF
--- a/src/bot/index.ts
+++ b/src/bot/index.ts
@@ -293,12 +293,6 @@ function bot(app: Probot) {
     const metadata = getMetadata(context.payload.repository.description)
     botLogger.info('Metadata: ', metadata)
 
-    // Ignore if it was the bot
-    if (context.payload.sender.type === 'Bot') {
-      botLogger.info('Push was from bot, skipping')
-      return
-    }
-
     // Call sync logic for either (1) fork branch change or (2) mirror default change
     if (!isMirror && !metadata.mirror) {
       await syncPushToMirror(context.payload)

--- a/src/server/git/controller.ts
+++ b/src/server/git/controller.ts
@@ -31,6 +31,25 @@ export const syncReposHandler = async ({
     const privateInstallationId = octokitData.private.installationId
     const privateAccessToken = octokitData.private.accessToken
 
+    const forkRef = await contributionOctokit.rest.git.getRef({
+      owner: input.forkOwner,
+      repo: input.forkName,
+      ref: `heads/${input.forkBranchName}`,
+    })
+
+    const mirrorRef = await privateOctokit.rest.git.getRef({
+      owner: input.mirrorOwner,
+      repo: input.mirrorName,
+      ref: `heads/${input.mirrorBranchName}`,
+    })
+
+    if (forkRef.data.object.sha === mirrorRef.data.object.sha) {
+      gitApiLogger.debug('Fork and mirror are already in sync')
+      return {
+        success: true,
+      }
+    }
+
     const forkRepo = await contributionOctokit.rest.repos.get({
       owner: input.forkOwner,
       repo: input.forkName,


### PR DESCRIPTION
# Pull Request

<!--
PR title needs to be prefixed with a conventional commit type
(build,chore,ci,docs,feat,fix,perf,refactor,revert,style,test)

It should also be brief and descriptive for a good changelog entry

examples: "feat: add new logger" or "fix: remove unused imports"
-->

## Proposed Changes

<!-- Describe what the changes are and link to a GitHub Issue if one exists -->

This change fixes an issue that can arise with the logic to filter out bot pushes where automated pushes from other applications will not be synced. It is still necessary to filter out private mirrors pushes to avoid infinite looping with the sync back logic so a check was added to the syncReposHandler to see if the two branches' head shas already match.

## Readiness Checklist

### Author/Contributor

- [x] If documentation is needed for this change, has that been included in this pull request
- [x] run `npm run lint` and fix any linting issues that have been introduced
- [x] run `npm run test` and run tests
- [ ] If publishing new data to the public (scorecards, security scan results, code quality results, live dashboards, etc.), please request review from `@jeffrey-luszcz`

### Reviewer

- [ ] Label as either `bug`, `documentation`, `enhancement`, `infrastructure`, `maintenance`, or `breaking`
