### PR TITLE
feat: support creating internal mirrors

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -30,3 +30,6 @@ PRIVATE_ORG=
 
 # Used to skip branch protection creation if organization level branch protections are used instead
 SKIP_BRANCH_PROTECTION_CREATION=
+
+# Used to create mirrors with internal visibility instead of private for use in GitHub Enterprise Cloud organizations
+CREATE_MIRRORS_WITH_INTERNAL_VISIBILITY=

--- a/env.mjs
+++ b/env.mjs
@@ -44,6 +44,11 @@ export const env = createEnv({
       .optional()
       .default('false')
       .transform((value) => value === 'true'),
+    CREATE_MIRRORS_WITH_INTERNAL_VISIBILITY: z
+      .enum(['true', 'false', ''])
+      .optional()
+      .default('false')
+      .transform((value) => value === 'true'),
   },
   /*
    * Environment variables available on the client (and server).
@@ -73,6 +78,8 @@ export const env = createEnv({
     ALLOWED_ORGS: process.env.ALLOWED_ORGS,
     SKIP_BRANCH_PROTECTION_CREATION:
       process.env.SKIP_BRANCH_PROTECTION_CREATION,
+    CREATE_MIRRORS_WITH_INTERNAL_VISIBILITY:
+      process.env.CREATE_MIRRORS_WITH_INTERNAL_VISIBILITY,
   },
   skipValidation: process.env.SKIP_ENV_VALIDATIONS === 'true',
 })

--- a/src/server/repos/controller.ts
+++ b/src/server/repos/controller.ts
@@ -132,7 +132,10 @@ export const createMirrorHandler = async ({
     newRepo = await privateOctokit.rest.repos.createInOrg({
       name: input.newRepoName,
       org: privateOrg,
-      private: true,
+      // @ts-expect-error because the rest API accepts internal as an option but the types aren't up to date
+      visibility: process.env.CREATE_MIRRORS_WITH_INTERNAL_VISIBILITY
+        ? 'internal'
+        : 'private',
       description: `Mirror of ${input.forkRepoOwner}/${input.forkRepoName}`,
       custom_properties: {
         fork: `${input.forkRepoOwner}/${input.forkRepoName}`,


### PR DESCRIPTION
# Pull Request

<!--
PR title needs to be prefixed with a conventional commit type
(build,chore,ci,docs,feat,fix,perf,refactor,revert,style,test)

It should also be brief and descriptive for a good changelog entry

examples: "feat: add new logger" or "fix: remove unused imports"
-->

## Proposed Changes

<!-- Describe what the changes are and link to a GitHub Issue if one exists -->

This change adds an environment variable that allows for mirrors to be created with internal visibility for use in GHEC deployments. The internal visibility still ensures that only enterprise members can see the mirrors but makes it so that all enterprise members can see the mirrors.

## Readiness Checklist

### Author/Contributor

- [x] If documentation is needed for this change, has that been included in this pull request
- [x] run `npm run lint` and fix any linting issues that have been introduced
- [x] run `npm run test` and run tests
- [ ] If publishing new data to the public (scorecards, security scan results, code quality results, live dashboards, etc.), please request review from `@jeffrey-luszcz`

### Reviewer

- [ ] Label as either `bug`, `documentation`, `enhancement`, `infrastructure`, `maintenance`, or `breaking`
