### PR TITLE
chore: fix engines and devEngines version syntax

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -61,7 +61,7 @@
         "typescript-eslint": "7.16.1"
       },
       "engines": {
-        "node": "18 || 20 || 22"
+        "node": "^18 || ^20 || ^22"
       }
     },
     "node_modules/@aashutoshrathi/word-wrap": {

--- a/package.json
+++ b/package.json
@@ -76,17 +76,17 @@
     }
   },
   "engines": {
-    "node": "18 || 20 || 22"
+    "node": "^18 || ^20 || ^22"
   },
   "devEngines": {
     "runtime": {
       "name": "node",
-      "version": "18 || 20 || 22",
+      "version": "^18 || ^20 || ^22",
       "onFail": "warn"
     },
     "packageManager": {
       "name": "npm",
-      "version": "10 || 11",
+      "version": "^10 || ^11",
       "onFail": "warn"
     }
   },


### PR DESCRIPTION
# Pull Request

## Proposed Changes

Fix `engines` and `devEngines` version syntax added in https://github.com/github-community-projects/private-mirrors/pull/344 to properly use semantic versions. This broke Dependabot, which I did not realize until recently. Dependabot currently shows this error when trying to update npm dependencies
```
Invalid package manager specification in package.json. The packageManager field must specify a valid semver version
```

## Readiness Checklist

### Author/Contributor

- [x] ~~If documentation is needed for this change, has that been included in this pull request~~
- [x] run `npm run lint` and fix any linting issues that have been introduced
- [x] run `npm run test` and run tests
- [x] ~~If publishing new data to the public (scorecards, security scan results, code quality results, live dashboards, etc.), please request review from `@jeffrey-luszcz`~~

### Reviewer

- [x] Label as either `bug`, `documentation`, `enhancement`, `infrastructure`, `maintenance`, or `breaking`
