### PR TITLE
chore: use array for packageManager as workaround

### DIFF
--- a/package.json
+++ b/package.json
@@ -84,11 +84,13 @@
       "version": "^18 || ^20 || ^22",
       "onFail": "warn"
     },
-    "packageManager": {
-      "name": "npm",
-      "version": "^10 || ^11",
-      "onFail": "warn"
-    }
+    "packageManager": [
+      {
+        "name": "npm",
+        "version": "^10 || ^11",
+        "onFail": "warn"
+      }
+    ]
   },
   "lint-staged": {
     "*": "npm run lint:fix"


### PR DESCRIPTION
# Pull Request

## Proposed Changes

Use an array for `packageManager` in `devEngines` as a workaround for https://github.com/dependabot/dependabot-core/issues/13722 that breaks Dependabot updates. This is due to https://github.com/nodejs/corepack/issues/729, which Dependabot uses under the hood. The fix is based on https://github.com/nextcloud-libraries/nextcloud-vite-config/issues/679, https://github.com/nextcloud-libraries/nextcloud-vite-config/commit/64400cd976c9159d41eadcbd1218b85615d0bb27.

## Readiness Checklist

### Author/Contributor

- [x] ~If documentation is needed for this change, has that been included in this pull request~
- [x] run `npm run lint` and fix any linting issues that have been introduced
- [x] run `npm run test` and run tests
- [x] ~If publishing new data to the public (scorecards, security scan results, code quality results, live dashboards, etc.), please request review from `@jeffrey-luszcz`~

### Reviewer

- [x] Label as either `bug`, `documentation`, `enhancement`, `infrastructure`, `maintenance`, or `breaking`
