### PR TITLE
chore: update octokit to 3.2.2

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -22,7 +22,7 @@
         "fuse.js": "7.1.0",
         "next": "14.2.35",
         "next-auth": "4.24.12",
-        "octokit": "3.2.1",
+        "octokit": "3.2.2",
         "probot": "13.4.7",
         "proxy-agent": "6.5.0",
         "react": "18.3.1",
@@ -12291,20 +12291,22 @@
       }
     },
     "node_modules/octokit": {
-      "version": "3.2.1",
-      "resolved": "https://registry.npmjs.org/octokit/-/octokit-3.2.1.tgz",
-      "integrity": "sha512-u+XuSejhe3NdIvty3Jod00JvTdAE/0/+XbhIDhefHbu+2OcTRHd80aCiH6TX19ZybJmwPQBKFQmHGxp0i9mJrg==",
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/octokit/-/octokit-3.2.2.tgz",
+      "integrity": "sha512-7Abo3nADdja8l/aglU6Y3lpnHSfv0tw7gFPiqzry/yCU+2gTAX7R1roJ8hJrxIK+S1j+7iqRJXtmuHJ/UDsBhQ==",
+      "license": "MIT",
       "dependencies": {
         "@octokit/app": "^14.0.2",
         "@octokit/core": "^5.0.0",
         "@octokit/oauth-app": "^6.0.0",
         "@octokit/plugin-paginate-graphql": "^4.0.0",
-        "@octokit/plugin-paginate-rest": "11.3.1",
-        "@octokit/plugin-rest-endpoint-methods": "13.2.2",
+        "@octokit/plugin-paginate-rest": "11.4.4-cjs.2",
+        "@octokit/plugin-rest-endpoint-methods": "13.3.2-cjs.1",
         "@octokit/plugin-retry": "^6.0.0",
         "@octokit/plugin-throttling": "^8.0.0",
         "@octokit/request-error": "^5.0.0",
-        "@octokit/types": "^13.0.0"
+        "@octokit/types": "^13.0.0",
+        "@octokit/webhooks": "^12.3.1"
       },
       "engines": {
         "node": ">= 18"
@@ -12374,32 +12376,18 @@
       }
     },
     "node_modules/octokit/node_modules/@octokit/openapi-types": {
-      "version": "23.0.1",
-      "resolved": "https://registry.npmjs.org/@octokit/openapi-types/-/openapi-types-23.0.1.tgz",
-      "integrity": "sha512-izFjMJ1sir0jn0ldEKhZ7xegCTj/ObmEDlEfpFrx4k/JyZSMRHbO3/rBwgE7f3m2DHt+RrNGIVw4wSmwnm3t/g==",
+      "version": "24.2.0",
+      "resolved": "https://registry.npmjs.org/@octokit/openapi-types/-/openapi-types-24.2.0.tgz",
+      "integrity": "sha512-9sIH3nSUttelJSXUrmGzl7QUBFul0/mB8HRYl3fOlgHbIWG+WnYDXU3v/2zMtAvuzZ/ed00Ei6on975FhBfzrg==",
       "license": "MIT"
     },
-    "node_modules/octokit/node_modules/@octokit/plugin-rest-endpoint-methods": {
-      "version": "13.2.2",
-      "resolved": "https://registry.npmjs.org/@octokit/plugin-rest-endpoint-methods/-/plugin-rest-endpoint-methods-13.2.2.tgz",
-      "integrity": "sha512-EI7kXWidkt3Xlok5uN43suK99VWqc8OaIMktY9d9+RNKl69juoTyxmLoWPIZgJYzi41qj/9zU7G/ljnNOJ5AFA==",
-      "dependencies": {
-        "@octokit/types": "^13.5.0"
-      },
-      "engines": {
-        "node": ">= 18"
-      },
-      "peerDependencies": {
-        "@octokit/core": "^5"
-      }
-    },
     "node_modules/octokit/node_modules/@octokit/types": {
-      "version": "13.8.0",
-      "resolved": "https://registry.npmjs.org/@octokit/types/-/types-13.8.0.tgz",
-      "integrity": "sha512-x7DjTIbEpEWXK99DMd01QfWy0hd5h4EN+Q7shkdKds3otGQP+oWE/y0A76i1OvH9fygo4ddvNf7ZvF0t78P98A==",
+      "version": "13.10.0",
+      "resolved": "https://registry.npmjs.org/@octokit/types/-/types-13.10.0.tgz",
+      "integrity": "sha512-ifLaO34EbbPj0Xgro4G5lP5asESjwHracYJvVaPIyXMuiuXLlhic3S47cBdTb+jfODkTE5YtGCLt3Ay3+J97sA==",
       "license": "MIT",
       "dependencies": {
-        "@octokit/openapi-types": "^23.0.1"
+        "@octokit/openapi-types": "^24.2.0"
       }
     },
     "node_modules/oidc-token-hash": {

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "fuse.js": "7.1.0",
     "next": "14.2.35",
     "next-auth": "4.24.12",
-    "octokit": "3.2.1",
+    "octokit": "3.2.2",
     "probot": "13.4.7",
     "proxy-agent": "6.5.0",
     "react": "18.3.1",
@@ -70,11 +70,6 @@
     "ts-node": "10.9.2",
     "typescript": "5.8.3",
     "typescript-eslint": "7.16.1"
-  },
-  "overrides": {
-    "octokit": {
-      "@octokit/plugin-paginate-rest": "11.4.4-cjs.2"
-    }
   },
   "engines": {
     "node": "^18 || ^20 || ^22"


### PR DESCRIPTION
# Pull Request

## Proposed Changes

Update `octokit` to `3.2.2`. This updates a transitive dependency as well and makes the override added in #330 no longer necessary. This will hopefully resolve #402 as well.

## Readiness Checklist

### Author/Contributor

- [x] ~If documentation is needed for this change, has that been included in this pull request~
- [x] run `npm run lint` and fix any linting issues that have been introduced
- [x] run `npm run test` and run tests
- [x] ~If publishing new data to the public (scorecards, security scan results, code quality results, live dashboards, etc.), please request review from `@jeffrey-luszcz`~

### Reviewer

- [x] Label as either `bug`, `documentation`, `enhancement`, `infrastructure`, `maintenance`, or `breaking`
