### PR TITLE
test: run tests across multiple Node.js versions

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -12,6 +12,7 @@ permissions:
 
 jobs:
   test:
+    name: Test on Node.js ${{ matrix.node-version }}
     runs-on: ubuntu-latest
     strategy:
       matrix:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -13,6 +13,9 @@ permissions:
 jobs:
   test:
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        node-version: [22, 24]
 
     steps:
       - name: Checkout code
@@ -23,7 +26,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
         with:
-          node-version-file: '.nvmrc'
+          node-version: ${{ matrix.node-version }}
           cache: 'npm'
 
       - name: Install Dependencies


### PR DESCRIPTION
## Changes

Add GitHub Actions matrix strategy to `.github/workflows/tests.yml` to run tests in parallel across all supported Node.js major versions (22 and 24). This ensures code compatibility is verified across the full range of supported versions.

## Closes
Closes #337

## Testing
- [ ] Verify tests pass on Node 22
- [ ] Verify tests pass on Node 24
- [ ] Verify matrix displays both versions in workflow run