### PR TITLE
chore: add type checking and linting for tests

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -5,6 +5,7 @@ import { fileURLToPath } from 'url'
 import js from '@eslint/js'
 import tsPlugin from '@typescript-eslint/eslint-plugin'
 import tsParser from '@typescript-eslint/parser'
+import jestPlugin from 'eslint-plugin-jest'
 
 const __filename = fileURLToPath(import.meta.url)
 const __dirname = dirname(__filename)
@@ -48,31 +49,30 @@ export default [
     },
   },
   {
-    // TODO: add linting for tests
-    // Test files - lint without type-checking (not in tsconfig.json project)
-    // TODO: add type checking for tests
-    // files: ['test/**/*.{ts,tsx}'],
-    // languageOptions: {
-    //   parser: tsParser,
-    //   globals: jestPlugin.environments.globals.globals,
-    // },
-    // plugins: {
-    //   '@typescript-eslint': tsPlugin,
-    //   jest: jestPlugin,
-    // },
-    // rules: {
-    //   ...tsPlugin.configs['recommended'].rules,
-    //   ...jestPlugin.configs['recommended'].rules,
-    //   '@typescript-eslint/no-unused-vars': [
-    //     'error',
-    //     { argsIgnorePattern: '^_', varsIgnorePattern: '^_' },
-    //   ],
-    //   // TODO: clean up conditional tests
-    //   'jest/no-conditional-expect': 'off',
-    // },
+    files: ['test/**/*.{ts,tsx}'],
+    languageOptions: {
+      parser: tsParser,
+      parserOptions: {
+        project: './tsconfig.json',
+      },
+      globals: jestPlugin.environments.globals.globals,
+    },
+    plugins: {
+      '@typescript-eslint': tsPlugin,
+      jest: jestPlugin,
+    },
+    rules: {
+      ...tsPlugin.configs['recommended'].rules,
+      ...jestPlugin.configs['recommended'].rules,
+      '@typescript-eslint/no-unused-vars': [
+        'error',
+        { argsIgnorePattern: '^_', varsIgnorePattern: '^_' },
+      ],
+      // TODO: clean up conditional tests
+      'jest/no-conditional-expect': 'off',
+    },
   },
   {
-    // TODO: lint tests
-    ignores: ['node_modules/', '.next/', 'build/', 'test/', '*.mjs', '*.js'],
+    ignores: ['node_modules/', '.next/', 'build/', '*.mjs', '*.js'],
   },
 ]

--- a/next.config.mjs
+++ b/next.config.mjs
@@ -6,6 +6,9 @@ const nextConfig = {
   compiler: {
     styledComponents: true,
   },
+  typescript: {
+    tsconfigPath: './tsconfig.build.json',
+  },
 }
 
 export default nextConfig

--- a/package-lock.json
+++ b/package-lock.json
@@ -51,6 +51,7 @@
         "dotenv-load": "3.0.0",
         "eslint": "9.39.2",
         "eslint-config-next": "16.1.6",
+        "eslint-plugin-jest": "29.15.2",
         "github-app-webhook-relay-polling": "2.0.0",
         "husky": "9.1.7",
         "jest": "29.7.0",
@@ -7988,6 +7989,36 @@
       "license": "ISC",
       "bin": {
         "semver": "bin/semver.js"
+      }
+    },
+    "node_modules/eslint-plugin-jest": {
+      "version": "29.15.2",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-jest/-/eslint-plugin-jest-29.15.2.tgz",
+      "integrity": "sha512-kEN4r9RZl1xcsb4arGq89LrcVdOUFII/JSCwtTPJyv16mDwmPrcuEQwpxqZHeINvcsd7oK5O/rhdGlxFRaZwvQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/utils": "^8.0.0"
+      },
+      "engines": {
+        "node": "^20.12.0 || ^22.0.0 || >=24.0.0"
+      },
+      "peerDependencies": {
+        "@typescript-eslint/eslint-plugin": "^8.0.0",
+        "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
+        "jest": "*",
+        "typescript": ">=4.8.4 <7.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@typescript-eslint/eslint-plugin": {
+          "optional": true
+        },
+        "jest": {
+          "optional": true
+        },
+        "typescript": {
+          "optional": true
+        }
       }
     },
     "node_modules/eslint-plugin-jsx-a11y": {

--- a/package.json
+++ b/package.json
@@ -61,6 +61,7 @@
     "dotenv-load": "3.0.0",
     "eslint": "9.39.2",
     "eslint-config-next": "16.1.6",
+    "eslint-plugin-jest": "29.15.2",
     "github-app-webhook-relay-polling": "2.0.0",
     "husky": "9.1.7",
     "jest": "29.7.0",

--- a/test/app.test.ts
+++ b/test/app.test.ts
@@ -14,6 +14,7 @@ import {
 } from '../src/bot/graphql'
 import forkCreatedPayload from './fixtures/fork.created.json'
 import mirrorCreatedPayload from './fixtures/mirror.created.json'
+import {type RepositoryCreatedEvent} from '@octokit/webhooks-types'
 
 const om = new Octomock()
 
@@ -104,7 +105,7 @@ describe('Webhooks events', () => {
     await probot.receive({
       id: forkCreatedPayload.action,
       name: 'repository',
-      payload: forkCreatedPayload as any,
+      payload: forkCreatedPayload as unknown as RepositoryCreatedEvent,
     })
 
     expect(mock.pendingMocks()).toStrictEqual([])
@@ -169,7 +170,7 @@ describe('Webhooks events', () => {
     await probot.receive({
       id: mirrorCreatedPayload.action,
       name: 'repository',
-      payload: mirrorCreatedPayload as any,
+      payload: mirrorCreatedPayload as unknown as RepositoryCreatedEvent,
     })
 
     expect(mock.pendingMocks()).toStrictEqual([])

--- a/test/app.test.ts
+++ b/test/app.test.ts
@@ -14,7 +14,7 @@ import {
 } from '../src/bot/graphql'
 import forkCreatedPayload from './fixtures/fork.created.json'
 import mirrorCreatedPayload from './fixtures/mirror.created.json'
-import {type RepositoryCreatedEvent} from '@octokit/webhooks-types'
+import { type RepositoryCreatedEvent } from '@octokit/webhooks-types'
 
 const om = new Octomock()
 

--- a/test/app.ts
+++ b/test/app.ts
@@ -9,7 +9,7 @@ import fs from 'fs'
 import path from 'path'
 import payload from './fixtures/installation.created.json'
 const issueCreatedBody = { body: 'Thanks for opening this issue!' }
-import {type InstallationCreatedEvent} from '@octokit/webhooks-types'
+import { type InstallationCreatedEvent } from '@octokit/webhooks-types'
 
 const privateKey = fs.readFileSync(
   path.join(__dirname, 'fixtures/mock-cert.pem'),

--- a/test/app.ts
+++ b/test/app.ts
@@ -9,6 +9,7 @@ import fs from 'fs'
 import path from 'path'
 import payload from './fixtures/installation.created.json'
 const issueCreatedBody = { body: 'Thanks for opening this issue!' }
+import {type InstallationCreatedEvent} from '@octokit/webhooks-types'
 
 const privateKey = fs.readFileSync(
   path.join(__dirname, 'fixtures/mock-cert.pem'),
@@ -33,7 +34,9 @@ describe('Webhooks events', () => {
     probot.load(app)
   })
 
-  test('creates a comment when an issue is opened', (done) => {
+  test('creates a comment when an issue is opened', () => {
+    let commentBody: Record<string, string> | null = null
+
     const mock = nock('https://api.github.com')
       // Test that we correctly return a test token
       .post('/app/installations/2/access_tokens')
@@ -46,19 +49,20 @@ describe('Webhooks events', () => {
 
       // Test that a comment is posted
       .post('/repos/hiimbex/testing-things/issues/1/comments', (body) => {
-        done(expect(body).toMatchObject(issueCreatedBody))
+        commentBody = body
         return body
       })
       .reply(200)
 
     // Receive a webhook event
-    probot
+    return probot
       .receive({
         id: payload.action,
         name: 'installation',
-        payload: payload as any,
+        payload: payload as unknown as InstallationCreatedEvent,
       })
       .then(() => {
+        expect(commentBody).toMatchObject(issueCreatedBody)
         expect(mock.pendingMocks()).toStrictEqual([])
       })
   })

--- a/test/octomock/index.ts
+++ b/test/octomock/index.ts
@@ -1,6 +1,7 @@
 // This is taken from https://github.com/Chocrates/octomock
+/* eslint-disable @typescript-eslint/no-explicit-any */
 
-let mockFunctions = {
+const mockFunctions = {
   config: {
     get: jest.fn(),
   },
@@ -307,7 +308,7 @@ export class Octomock {
     rest: Record<string, Record<string, jest.Mock>>
     config: Record<string, jest.Mock>
   }
-  defaultContext: { payload: { issue: { body: string; user: {} } } }
+  defaultContext: { payload: { issue: { body: string; user: object } } }
 
   mockGitHubImplementation: {
     context: {
@@ -400,9 +401,9 @@ export class Octomock {
 
   updateContext(context: {
     [x: string]: any
-    payload?: { issue: { body: string; user: {} } }
+    payload?: { issue: { body: string; user: object } }
   }) {
-    for (let property in context) {
+    for (const property in context) {
       this.mockGitHubImplementation.context[property] = context[property]
     }
   }

--- a/test/server/git/controller.test.ts
+++ b/test/server/git/controller.test.ts
@@ -2,6 +2,7 @@ import { syncReposHandler } from '../../../src/server/git/controller'
 import * as auth from '../../../src/utils/auth'
 import * as dir from '../../../src/utils/dir'
 import simpleGit from 'simple-git'
+import type { SyncReposSchema } from '../../../src/server/git/schema'
 
 const getRefSpy = jest.fn()
 
@@ -25,7 +26,7 @@ const fakeOctokitData = {
     },
   },
   installationId: 'fake-installation-id',
-}
+} as unknown as SyncReposSchema['source']['octokit']
 
 jest.mock('simple-git')
 const simpleGitMock = simpleGit as jest.Mock
@@ -354,7 +355,7 @@ describe('Git controller', () => {
     expect(gitMock.push).toHaveBeenCalledWith(['--force'])
   })
 
-  it('should be syncable, have the environment flag set to true, be a merge commit, and be a merge to main branch, ', async () => {
+  it('should be syncable, have the environment flag set to true, be a merge commit, and be a merge to main branch,', async () => {
     getRefSpy
       .mockResolvedValueOnce({
         data: {

--- a/tsconfig.build.json
+++ b/tsconfig.build.json
@@ -1,0 +1,4 @@
+{
+  "extends": "./tsconfig.json",
+  "exclude": ["node_modules", "test"]
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -74,7 +74,7 @@
       }
     ]
   },
-  "include": ["src", ".next/types/**/*.ts", ".next/dev/types/**/*.ts"],
-  "exclude": ["node_modules", "test"],
+  "include": ["src", "test", ".next/types/**/*.ts", ".next/dev/types/**/*.ts"],
+  "exclude": ["node_modules"],
   "compileOnSave": false
 }


### PR DESCRIPTION
## Summary

This PR implements the changes requested in #411 to add type checking and linting for test files.

## Changes

- **tsconfig.json**: Include test directory for development with strict type checking
- **tsconfig.build.json** (new): Extends tsconfig.json but excludes tests and node_modules for production builds
- **next.config.mjs**: Configure Next.js to use tsconfig.build.json via tsconfigPath property
- **eslint.config.mjs**: Uncomment and enable test linting with Jest plugin configuration
- **package.json**: Add eslint-plugin-jest (v29.15.2) dependency
- **Test file fixes**: Resolved all TypeScript and ESLint errors in test files

## Architecture Benefits

✅ **Development**: Tests included in type checking → catches bugs early  
✅ **Production builds**: Tests excluded via tsconfig.build.json  
✅ **Code quality**: Tests have same type safety and linting as production code  
✅ **Clean separation**: Main tsconfig for dev/linting, tsconfig.build for builds  

## Testing

- ✅ All 19 tests pass
- ✅ Type checking passes (both tsconfig.json and tsconfig.build.json)
- ✅ ESLint passes (no errors in test files)
- ✅ Build succeeds

Fixes #411