### PR TITLE
feat: add input validation for mirror names

### DIFF
--- a/src/app/components/dialog/CreateMirrorDialog.tsx
+++ b/src/app/components/dialog/CreateMirrorDialog.tsx
@@ -8,8 +8,11 @@ import {
   TextInput,
 } from '@primer/react'
 import { Dialog } from '@primer/react/drafts'
+import { mirrorNameSchema } from 'server/repos/schema'
 
 import { useState } from 'react'
+
+const DEFAULT_REPO_NAME = 'repository-name'
 
 interface CreateMirrorDialogProps {
   orgLogin: string
@@ -29,11 +32,18 @@ export const CreateMirrorDialog = ({
   createMirror,
 }: CreateMirrorDialogProps) => {
   // set to default value of 'repository-name' for display purposes
-  const [repoName, setRepoName] = useState('repository-name')
+  const [repoName, setRepoName] = useState(DEFAULT_REPO_NAME)
 
   if (!isOpen) {
     return null
   }
+
+  const hasUserInput = repoName !== DEFAULT_REPO_NAME && repoName !== ''
+  const validation = mirrorNameSchema.safeParse(repoName)
+  const validationError =
+    hasUserInput && !validation.success
+      ? validation.error.issues[0].message
+      : null
 
   return (
     <Dialog
@@ -44,7 +54,7 @@ export const CreateMirrorDialog = ({
           content: 'Cancel',
           onClick: () => {
             closeDialog()
-            setRepoName('repository-name')
+            setRepoName(DEFAULT_REPO_NAME)
           },
         },
         {
@@ -52,14 +62,14 @@ export const CreateMirrorDialog = ({
           variant: 'primary',
           onClick: () => {
             createMirror({ repoName, branchName: repoName })
-            setRepoName('repository-name')
+            setRepoName(DEFAULT_REPO_NAME)
           },
-          disabled: repoName === 'repository-name' || repoName === '',
+          disabled: !hasUserInput || !validation.success,
         },
       ]}
       onClose={() => {
         closeDialog()
-        setRepoName('repository-name')
+        setRepoName(DEFAULT_REPO_NAME)
       }}
       width="large"
     >
@@ -71,17 +81,24 @@ export const CreateMirrorDialog = ({
             block
             placeholder="e.g. repository-name"
             maxLength={100}
+            validationStatus={validationError ? 'error' : undefined}
           />
-          <FormControl.Caption>
-            This is a private mirror of{' '}
-            <Link
-              href={`https://github.com/${forkParentOwnerLogin}/${forkParentName}`}
-              target="_blank"
-              rel="noreferrer noopener"
-            >
-              {forkParentOwnerLogin}/{forkParentName}
-            </Link>
-          </FormControl.Caption>
+          {validationError ? (
+            <FormControl.Validation variant="error">
+              {validationError}
+            </FormControl.Validation>
+          ) : (
+            <FormControl.Caption>
+              This is a private mirror of{' '}
+              <Link
+                href={`https://github.com/${forkParentOwnerLogin}/${forkParentName}`}
+                target="_blank"
+                rel="noreferrer noopener"
+              >
+                {forkParentOwnerLogin}/{forkParentName}
+              </Link>
+            </FormControl.Caption>
+          )}
         </FormControl>
         <FormControl>
           <FormControl.Label>Mirror location</FormControl.Label>

--- a/src/app/components/dialog/EditMirrorDialog.tsx
+++ b/src/app/components/dialog/EditMirrorDialog.tsx
@@ -8,6 +8,7 @@ import {
   TextInput,
 } from '@primer/react'
 import { Dialog } from '@primer/react/drafts'
+import { mirrorNameSchema } from 'server/repos/schema'
 
 import { useEffect, useState } from 'react'
 
@@ -47,6 +48,13 @@ export const EditMirrorDialog = ({
     return null
   }
 
+  const hasUserInput = newMirrorName !== mirrorName && newMirrorName !== ''
+  const validation = mirrorNameSchema.safeParse(newMirrorName)
+  const validationError =
+    hasUserInput && !validation.success
+      ? validation.error.issues[0].message
+      : null
+
   return (
     <Dialog
       title="Edit mirror"
@@ -70,7 +78,7 @@ export const EditMirrorDialog = ({
             })
             setNewMirrorName(mirrorName)
           },
-          disabled: newMirrorName === mirrorName || newMirrorName === '',
+          disabled: !hasUserInput || !validation.success,
         },
       ]}
       onClose={() => {
@@ -87,17 +95,24 @@ export const EditMirrorDialog = ({
             block
             placeholder={mirrorName}
             maxLength={100}
+            validationStatus={validationError ? 'error' : undefined}
           />
-          <FormControl.Caption>
-            This is a private mirror of{' '}
-            <Link
-              href={`https://github.com/${forkParentOwnerLogin}/${forkParentName}`}
-              target="_blank"
-              rel="noreferrer noopener"
-            >
-              {forkParentOwnerLogin}/{forkParentName}
-            </Link>
-          </FormControl.Caption>
+          {validationError ? (
+            <FormControl.Validation variant="error">
+              {validationError}
+            </FormControl.Validation>
+          ) : (
+            <FormControl.Caption>
+              This is a private mirror of{' '}
+              <Link
+                href={`https://github.com/${forkParentOwnerLogin}/${forkParentName}`}
+                target="_blank"
+                rel="noreferrer noopener"
+              >
+                {forkParentOwnerLogin}/{forkParentName}
+              </Link>
+            </FormControl.Caption>
+          )}
         </FormControl>
         <FormControl>
           <FormControl.Label>Mirror location</FormControl.Label>

--- a/src/server/repos/schema.ts
+++ b/src/server/repos/schema.ts
@@ -1,11 +1,26 @@
 import { z } from 'zod'
 
+export const mirrorNameSchema = z
+  .string()
+  .min(1, 'Mirror name is required')
+  .max(100, 'Mirror name cannot exceed 100 characters')
+  .regex(
+    /^[A-Za-z0-9._-]+$/,
+    'Only letters, numbers, hyphens, underscores, and periods are allowed',
+  )
+  .refine((name) => name !== '.' && name !== '..', {
+    message: 'Mirror name cannot be "." or ".."',
+  })
+  .refine((name) => !name.toLowerCase().endsWith('.git'), {
+    message: 'Mirror name cannot end with ".git"',
+  })
+
 export const CreateMirrorSchema = z.object({
   orgId: z.string(),
   forkRepoOwner: z.string(),
   forkRepoName: z.string(),
   forkId: z.string(),
-  newRepoName: z.string().max(100),
+  newRepoName: mirrorNameSchema,
   newBranchName: z.string(),
 })
 
@@ -17,7 +32,7 @@ export const ListMirrorsSchema = z.object({
 export const EditMirrorSchema = z.object({
   orgId: z.string(),
   mirrorName: z.string(),
-  newMirrorName: z.string().max(100),
+  newMirrorName: mirrorNameSchema,
 })
 
 export const DeleteMirrorSchema = z.object({

--- a/test/server/repos.test.ts
+++ b/test/server/repos.test.ts
@@ -354,7 +354,7 @@ describe('Repos router', () => {
       })
       .catch((error) => {
         expect(error.message).toMatch(
-          /String must contain at most 100 character\(s\)/,
+          /Mirror name cannot exceed 100 characters/,
         )
       })
   })


### PR DESCRIPTION
# Pull Request

<!--
PR title needs to be prefixed with a conventional commit type
(build,chore,ci,docs,feat,fix,perf,refactor,revert,style,test)

It should also be brief and descriptive for a good changelog entry

examples: "feat: add new logger" or "fix: remove unused imports"
-->
## Summary
This PR: 

- Adds a shared mirrorNameSchema (Zod) enforcing GitHub's repo-name rules: allowed chars [A-Za-z0-9._-], 1–100 chars, not . or .., and no .git suffix.
- Applies it to CreateMirrorSchema.newRepoName and EditMirrorSchema.newMirrorName, so tRPC rejects invalid names server-side.
- Wires the same schema into CreateMirrorDialog and EditMirrorDialog: invalid input renders an inline FormControl.Validation error and disables the Confirm button.

Out of scope
- Case-insensitive uniqueness (MyRepo vs myrepo) — requires a live API check and is already covered by the existing "repo already exists" path in createMirrorHandler.
- Normalization (spaces → hyphens, unicode → hyphens). Per #445 we reject rather than silently transform.


## Screenshot
<img width="559" height="430" alt="Screenshot 2026-04-24 at 10 12 08 PM" src="https://github.com/user-attachments/assets/db833b6e-8e44-4398-8a5c-2d833a01d850" />
<img width="547" height="429" alt="Screenshot 2026-04-24 at 10 12 25 PM" src="https://github.com/user-attachments/assets/cbfe43fb-2e79-431c-ad12-eb55dc9e1e56" />
<img width="522" height="435" alt="Screenshot 2026-04-24 at 10 12 40 PM" src="https://github.com/user-attachments/assets/15c85955-4cd3-40e9-aa61-d434d654e85e" />

## Proposed Changes

<!-- Describe what the changes are and link to a GitHub Issue if one exists -->
The proposed changes will use GitHub's repo naming constraints in order to prevent users from creating a mirror with a name using disallowed chars and to enforce certain naming rules:

### Disallowed Characters
The following characters are not allowed in a repository name:
* Spaces: Spaces are automatically replaced with hyphens during creation.
* Special symbols: Most symbols, such as +, &, @, !, $, %, ^, :, and /, are disallowed.
* Emojis: Emojis are blocked and cannot be used in repository names.
* Unicode/Non-ASCII: Generally, non-ASCII characters are converted to hyphens to ensure URL compatibility. 

### Allowed Characters
A valid GitHub repository name must only consist of the following:
* Alphanumeric characters: Letters (A-Z, a-z) and numbers (0-9).
* Hyphens (-): Often used as word separators.
* Underscores (_): Allowed within the name.
* Periods (.): Allowed, but the name cannot be just . or ... 

### Additional Constraints
* Length: Names can be up to 100 characters (specifically code points).
* Reserved Names: You cannot use names that are purely . or .., nor can names end with .git.
* Case Sensitivity: While GitHub preserves casing in display, repository names are case-insensitive for URLs; you cannot have two repositories named MyRepo and myrepo under the same account.
* Normalization: If you attempt to use illegal characters through certain tools, GitHub may normalize them by replacing all unsupported characters with single hyphens.

Closes #445 

## Readiness Checklist

### Author/Contributor

- [ ] If documentation is needed for this change, has that been included in this pull request
- [x] run `npm run lint` and fix any linting issues that have been introduced
- [x] run `npm run test` and run tests
