### PR TITLE
test: do not use vitest globals

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -68,6 +68,13 @@ export default [
         'error',
         { argsIgnorePattern: '^_', varsIgnorePattern: '^_' },
       ],
+      'vitest/consistent-test-it': [
+        'error',
+        {
+          fn: 'test',
+          withinDescribe: 'it',
+        },
+      ],
       // TODO: clean up conditional tests
       'vitest/no-conditional-expect': 'off',
     },

--- a/test/app.test.ts
+++ b/test/app.test.ts
@@ -1,3 +1,4 @@
+import { describe, beforeEach, test, expect } from 'vitest'
 import nock from 'nock'
 
 // Requiring our app implementation

--- a/test/app.test.ts
+++ b/test/app.test.ts
@@ -1,4 +1,4 @@
-import { describe, beforeEach, test, expect } from 'vitest'
+import { describe, beforeEach, it, expect } from 'vitest'
 import nock from 'nock'
 
 // Requiring our app implementation
@@ -47,7 +47,7 @@ describe('Webhooks events', () => {
     probot.load(app.default)
   })
 
-  test('creates branch protections for a fork', async () => {
+  it('creates branch protections for a fork', async () => {
     const mock = nock('https://api.github.com')
       // Test that we can hit the app endpoints
       .get('/app')
@@ -112,7 +112,7 @@ describe('Webhooks events', () => {
     expect(mock.pendingMocks()).toStrictEqual([])
   })
 
-  test('creates branch protections for a mirror', async () => {
+  it('creates branch protections for a mirror', async () => {
     const mock = nock('https://api.github.com')
       // Test that we can hit the app endpoints
       .get('/app')

--- a/test/app.ts
+++ b/test/app.ts
@@ -1,4 +1,4 @@
-import { describe, beforeEach, afterEach, test, expect } from 'vitest'
+import { describe, beforeEach, afterEach, it, expect } from 'vitest'
 import nock from 'nock'
 
 // Requiring our app implementation
@@ -35,7 +35,7 @@ describe('Webhooks events', () => {
     probot.load(app)
   })
 
-  test('creates a comment when an issue is opened', () => {
+  it('creates a comment when an issue is opened', () => {
     let commentBody: Record<string, string> | null = null
 
     const mock = nock('https://api.github.com')

--- a/test/app.ts
+++ b/test/app.ts
@@ -1,3 +1,4 @@
+import { describe, beforeEach, afterEach, test, expect } from 'vitest'
 import nock from 'nock'
 
 // Requiring our app implementation

--- a/test/config.test.ts
+++ b/test/config.test.ts
@@ -1,3 +1,4 @@
+import { vi, describe, beforeEach, test, expect } from 'vitest'
 import * as config from '../src/bot/config'
 import { Octomock } from './octomock'
 const om = new Octomock()
@@ -15,7 +16,7 @@ describe('PMA Config', () => {
     delete process.env.PRIVATE_ORG
   })
 
-  it('should use env variables when they are available', async () => {
+  test('should use env variables when they are available', async () => {
     // set the env variables
     process.env.PUBLIC_ORG = 'github'
     process.env.PRIVATE_ORG = 'github-test'
@@ -28,7 +29,7 @@ describe('PMA Config', () => {
     })
   })
 
-  it('should use the public org for both values when only PUBLIC_ORG provided', async () => {
+  test('should use the public org for both values when only PUBLIC_ORG provided', async () => {
     // set the env variables
     process.env.PUBLIC_ORG = 'github'
 
@@ -40,7 +41,7 @@ describe('PMA Config', () => {
     })
   })
 
-  it('should throw an error when no env and no org id provided', async () => {
+  test('should throw an error when no env and no org id provided', async () => {
     await config.getConfig().catch((error) => {
       expect(error.message).toContain('Organization ID is required')
     })

--- a/test/config.test.ts
+++ b/test/config.test.ts
@@ -1,4 +1,4 @@
-import { vi, describe, beforeEach, test, expect } from 'vitest'
+import { vi, describe, beforeEach, it, expect } from 'vitest'
 import * as config from '../src/bot/config'
 import { Octomock } from './octomock'
 const om = new Octomock()
@@ -16,7 +16,7 @@ describe('PMA Config', () => {
     delete process.env.PRIVATE_ORG
   })
 
-  test('should use env variables when they are available', async () => {
+  it('should use env variables when they are available', async () => {
     // set the env variables
     process.env.PUBLIC_ORG = 'github'
     process.env.PRIVATE_ORG = 'github-test'
@@ -29,7 +29,7 @@ describe('PMA Config', () => {
     })
   })
 
-  test('should use the public org for both values when only PUBLIC_ORG provided', async () => {
+  it('should use the public org for both values when only PUBLIC_ORG provided', async () => {
     // set the env variables
     process.env.PUBLIC_ORG = 'github'
 
@@ -41,7 +41,7 @@ describe('PMA Config', () => {
     })
   })
 
-  test('should throw an error when no env and no org id provided', async () => {
+  it('should throw an error when no env and no org id provided', async () => {
     await config.getConfig().catch((error) => {
       expect(error.message).toContain('Organization ID is required')
     })

--- a/test/octomock/index.ts
+++ b/test/octomock/index.ts
@@ -1,7 +1,7 @@
 // This is taken from https://github.com/Chocrates/octomock
 /* eslint-disable @typescript-eslint/no-explicit-any */
 
-import type { Mock } from 'vitest'
+import { vi, type Mock } from 'vitest'
 
 const mockFunctions = {
   config: {

--- a/test/server/auth.test.ts
+++ b/test/server/auth.test.ts
@@ -1,4 +1,4 @@
-import { vi, describe, beforeEach, test, expect } from 'vitest'
+import { vi, describe, beforeEach, it, expect } from 'vitest'
 import { healthCheckerRouter } from '../../src/app/api/trpc/trpc-router'
 import { Octomock } from '../octomock'
 import { createTestContext } from '../utils/auth'
@@ -15,7 +15,7 @@ describe('Git router', () => {
     vi.resetAllMocks()
   })
 
-  test('should allow users that are authenticated', async () => {
+  it('should allow users that are authenticated', async () => {
     const caller =
       t.createCallerFactory(healthCheckerRouter)(createTestContext())
 
@@ -35,7 +35,7 @@ describe('Git router', () => {
     )
   })
 
-  test('should throw on invalid sessions', async () => {
+  it('should throw on invalid sessions', async () => {
     const caller = t.createCallerFactory(healthCheckerRouter)(
       createTestContext({
         user: {

--- a/test/server/auth.test.ts
+++ b/test/server/auth.test.ts
@@ -1,3 +1,4 @@
+import { vi, describe, beforeEach, test, expect } from 'vitest'
 import { healthCheckerRouter } from '../../src/app/api/trpc/trpc-router'
 import { Octomock } from '../octomock'
 import { createTestContext } from '../utils/auth'
@@ -14,7 +15,7 @@ describe('Git router', () => {
     vi.resetAllMocks()
   })
 
-  it('should allow users that are authenticated', async () => {
+  test('should allow users that are authenticated', async () => {
     const caller =
       t.createCallerFactory(healthCheckerRouter)(createTestContext())
 
@@ -34,7 +35,7 @@ describe('Git router', () => {
     )
   })
 
-  it('should throw on invalid sessions', async () => {
+  test('should throw on invalid sessions', async () => {
     const caller = t.createCallerFactory(healthCheckerRouter)(
       createTestContext({
         user: {

--- a/test/server/config.test.ts
+++ b/test/server/config.test.ts
@@ -1,4 +1,4 @@
-import { vi, describe, beforeEach, test, expect } from 'vitest'
+import { vi, describe, beforeEach, it, expect } from 'vitest'
 import fs from 'fs'
 import path from 'path'
 
@@ -32,7 +32,7 @@ describe('Config router', () => {
     vi.resetAllMocks()
   })
 
-  test('should fetch the values from the config', async () => {
+  it('should fetch the values from the config', async () => {
     const caller = configRouter.createCaller(createTestContext())
 
     const configSpy = vi.spyOn(config, 'getConfig').mockResolvedValue({

--- a/test/server/config.test.ts
+++ b/test/server/config.test.ts
@@ -1,3 +1,4 @@
+import { vi, describe, beforeEach, test, expect } from 'vitest'
 import fs from 'fs'
 import path from 'path'
 
@@ -31,7 +32,7 @@ describe('Config router', () => {
     vi.resetAllMocks()
   })
 
-  it('should fetch the values from the config', async () => {
+  test('should fetch the values from the config', async () => {
     const caller = configRouter.createCaller(createTestContext())
 
     const configSpy = vi.spyOn(config, 'getConfig').mockResolvedValue({

--- a/test/server/git/controller.test.ts
+++ b/test/server/git/controller.test.ts
@@ -1,4 +1,4 @@
-import { vi, describe, beforeEach, test, expect } from 'vitest'
+import { vi, describe, beforeEach, it, expect } from 'vitest'
 import { syncReposHandler } from '../../../src/server/git/controller'
 import * as auth from '../../../src/utils/auth'
 import * as dir from '../../../src/utils/dir'
@@ -58,7 +58,7 @@ describe('Git controller', () => {
     gitMock.show.mockReset()
   })
 
-  test('should not be syncable', async () => {
+  it('should not be syncable', async () => {
     getRefSpy
       .mockResolvedValueOnce({
         data: {
@@ -121,7 +121,7 @@ describe('Git controller', () => {
     ])
   })
 
-  test('should be syncable, but have the environment flag set to false', async () => {
+  it('should be syncable, but have the environment flag set to false', async () => {
     getRefSpy
       .mockResolvedValueOnce({
         data: {
@@ -192,7 +192,7 @@ describe('Git controller', () => {
     expect(gitMock.push).toHaveBeenCalledWith(['--force'])
   })
 
-  test('should be syncable, have the environment flag set to true, but not be a merge commit', async () => {
+  it('should be syncable, have the environment flag set to true, but not be a merge commit', async () => {
     getRefSpy
       .mockResolvedValueOnce({
         data: {
@@ -270,7 +270,7 @@ describe('Git controller', () => {
     expect(gitMock.push).toHaveBeenCalledWith(['--force'])
   })
 
-  test('should be syncable, have the environment flag set to true, be a merge commit, but not be a merge to main branch', async () => {
+  it('should be syncable, have the environment flag set to true, be a merge commit, but not be a merge to main branch', async () => {
     getRefSpy
       .mockResolvedValueOnce({
         data: {
@@ -353,7 +353,7 @@ describe('Git controller', () => {
     expect(gitMock.push).toHaveBeenCalledWith(['--force'])
   })
 
-  test('should be syncable, have the environment flag set to true, be a merge commit, and be a merge to main branch,', async () => {
+  it('should be syncable, have the environment flag set to true, be a merge commit, and be a merge to main branch,', async () => {
     getRefSpy
       .mockResolvedValueOnce({
         data: {

--- a/test/server/git/controller.test.ts
+++ b/test/server/git/controller.test.ts
@@ -1,3 +1,4 @@
+import { vi, describe, beforeEach, test, expect } from 'vitest'
 import { syncReposHandler } from '../../../src/server/git/controller'
 import * as auth from '../../../src/utils/auth'
 import * as dir from '../../../src/utils/dir'
@@ -57,7 +58,7 @@ describe('Git controller', () => {
     gitMock.show.mockReset()
   })
 
-  it('should not be syncable', async () => {
+  test('should not be syncable', async () => {
     getRefSpy
       .mockResolvedValueOnce({
         data: {
@@ -120,7 +121,7 @@ describe('Git controller', () => {
     ])
   })
 
-  it('should be syncable, but have the environment flag set to false', async () => {
+  test('should be syncable, but have the environment flag set to false', async () => {
     getRefSpy
       .mockResolvedValueOnce({
         data: {
@@ -191,7 +192,7 @@ describe('Git controller', () => {
     expect(gitMock.push).toHaveBeenCalledWith(['--force'])
   })
 
-  it('should be syncable, have the environment flag set to true, but not be a merge commit', async () => {
+  test('should be syncable, have the environment flag set to true, but not be a merge commit', async () => {
     getRefSpy
       .mockResolvedValueOnce({
         data: {
@@ -269,7 +270,7 @@ describe('Git controller', () => {
     expect(gitMock.push).toHaveBeenCalledWith(['--force'])
   })
 
-  it('should be syncable, have the environment flag set to true, be a merge commit, but not be a merge to main branch', async () => {
+  test('should be syncable, have the environment flag set to true, be a merge commit, but not be a merge to main branch', async () => {
     getRefSpy
       .mockResolvedValueOnce({
         data: {
@@ -352,7 +353,7 @@ describe('Git controller', () => {
     expect(gitMock.push).toHaveBeenCalledWith(['--force'])
   })
 
-  it('should be syncable, have the environment flag set to true, be a merge commit, and be a merge to main branch,', async () => {
+  test('should be syncable, have the environment flag set to true, be a merge commit, and be a merge to main branch,', async () => {
     getRefSpy
       .mockResolvedValueOnce({
         data: {

--- a/test/server/repos.test.ts
+++ b/test/server/repos.test.ts
@@ -1,3 +1,4 @@
+import { vi, describe, beforeEach, test, expect } from 'vitest'
 // TODO: We should only mock out clone and push but keep the rest of the options
 // the same. This will allow us to test the actual git commands.
 const stubbedGit = {
@@ -108,7 +109,7 @@ describe('Repos router', () => {
     process.env = { ...UNMODIFIED_ENV }
   })
 
-  it('should create a mirror when repo does not exist', async () => {
+  test('should create a mirror when repo does not exist', async () => {
     const caller = t.createCallerFactory(reposRouter)(createTestContext())
 
     const configSpy = vi.spyOn(config, 'getConfig').mockResolvedValue({
@@ -153,7 +154,7 @@ describe('Repos router', () => {
     })
   })
 
-  it('should throw an error when repo already exists', async () => {
+  test('should throw an error when repo already exists', async () => {
     const caller = t.createCallerFactory(reposRouter)(createTestContext())
 
     const configSpy = vi.spyOn(config, 'getConfig').mockResolvedValue({
@@ -187,7 +188,7 @@ describe('Repos router', () => {
     expect(stubbedGit.clone).toHaveBeenCalledTimes(0)
   })
 
-  it('should cleanup repos when there is an error', async () => {
+  test('should cleanup repos when there is an error', async () => {
     const caller = t.createCallerFactory(reposRouter)(createTestContext())
 
     const configSpy = vi.spyOn(config, 'getConfig').mockResolvedValue({
@@ -236,7 +237,7 @@ describe('Repos router', () => {
     expect(stubbedGit.clone).toHaveBeenCalledTimes(1)
   })
 
-  it('dual-org: should cleanup repos when there is an error', async () => {
+  test('dual-org: should cleanup repos when there is an error', async () => {
     const caller = t.createCallerFactory(reposRouter)(createTestContext())
 
     const configSpy = vi.spyOn(config, 'getConfig').mockResolvedValue({
@@ -286,7 +287,7 @@ describe('Repos router', () => {
     expect(stubbedGit.clone).toHaveBeenCalledTimes(1)
   })
 
-  it('should create an internal repo when the CREATE_MIRRORS_WITH_INTERNAL_VISIBILITY flag is used', async () => {
+  test('should create an internal repo when the CREATE_MIRRORS_WITH_INTERNAL_VISIBILITY flag is used', async () => {
     const caller = t.createCallerFactory(reposRouter)(createTestContext())
 
     const configSpy = vi.spyOn(config, 'getConfig').mockResolvedValue({
@@ -340,7 +341,7 @@ describe('Repos router', () => {
     })
   })
 
-  it('reject repository names over the character limit', async () => {
+  test('reject repository names over the character limit', async () => {
     const caller = t.createCallerFactory(reposRouter)(createTestContext())
 
     await caller

--- a/test/server/repos.test.ts
+++ b/test/server/repos.test.ts
@@ -1,4 +1,4 @@
-import { vi, describe, beforeEach, test, expect } from 'vitest'
+import { vi, describe, beforeEach, it, expect } from 'vitest'
 // TODO: We should only mock out clone and push but keep the rest of the options
 // the same. This will allow us to test the actual git commands.
 const stubbedGit = {
@@ -109,7 +109,7 @@ describe('Repos router', () => {
     process.env = { ...UNMODIFIED_ENV }
   })
 
-  test('should create a mirror when repo does not exist', async () => {
+  it('should create a mirror when repo does not exist', async () => {
     const caller = t.createCallerFactory(reposRouter)(createTestContext())
 
     const configSpy = vi.spyOn(config, 'getConfig').mockResolvedValue({
@@ -154,7 +154,7 @@ describe('Repos router', () => {
     })
   })
 
-  test('should throw an error when repo already exists', async () => {
+  it('should throw an error when repo already exists', async () => {
     const caller = t.createCallerFactory(reposRouter)(createTestContext())
 
     const configSpy = vi.spyOn(config, 'getConfig').mockResolvedValue({
@@ -188,7 +188,7 @@ describe('Repos router', () => {
     expect(stubbedGit.clone).toHaveBeenCalledTimes(0)
   })
 
-  test('should cleanup repos when there is an error', async () => {
+  it('should cleanup repos when there is an error', async () => {
     const caller = t.createCallerFactory(reposRouter)(createTestContext())
 
     const configSpy = vi.spyOn(config, 'getConfig').mockResolvedValue({
@@ -237,7 +237,7 @@ describe('Repos router', () => {
     expect(stubbedGit.clone).toHaveBeenCalledTimes(1)
   })
 
-  test('dual-org: should cleanup repos when there is an error', async () => {
+  it('dual-org: should cleanup repos when there is an error', async () => {
     const caller = t.createCallerFactory(reposRouter)(createTestContext())
 
     const configSpy = vi.spyOn(config, 'getConfig').mockResolvedValue({
@@ -287,7 +287,7 @@ describe('Repos router', () => {
     expect(stubbedGit.clone).toHaveBeenCalledTimes(1)
   })
 
-  test('should create an internal repo when the CREATE_MIRRORS_WITH_INTERNAL_VISIBILITY flag is used', async () => {
+  it('should create an internal repo when the CREATE_MIRRORS_WITH_INTERNAL_VISIBILITY flag is used', async () => {
     const caller = t.createCallerFactory(reposRouter)(createTestContext())
 
     const configSpy = vi.spyOn(config, 'getConfig').mockResolvedValue({
@@ -341,7 +341,7 @@ describe('Repos router', () => {
     })
   })
 
-  test('reject repository names over the character limit', async () => {
+  it('reject repository names over the character limit', async () => {
     const caller = t.createCallerFactory(reposRouter)(createTestContext())
 
     await caller

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -74,13 +74,7 @@
       }
     ]
   },
-  "include": [
-    "src",
-    "test",
-    ".next/types/**/*.ts",
-    ".next/dev/types/**/*.ts",
-    "vitest.d.ts"
-  ],
+  "include": ["src", "test", ".next/types/**/*.ts", ".next/dev/types/**/*.ts"],
   "exclude": ["node_modules"],
   "compileOnSave": false
 }

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -4,7 +4,6 @@ import tsconfigPaths from 'vite-tsconfig-paths'
 export default defineConfig({
   plugins: [tsconfigPaths()],
   test: {
-    globals: true,
     environment: 'node',
     include: [
       'test/**/*.{test,spec}.{ts,tsx}',

--- a/vitest.d.ts
+++ b/vitest.d.ts
@@ -1,1 +1,0 @@
-/// <reference types="vitest/globals" />


### PR DESCRIPTION
# Pull Request

## Proposed Changes

Remove use of Vitest globals. Follow-on to #454, addressing feedback.

Co-authored-by: Copilot <copilot@github.com>

## Readiness Checklist

### Author/Contributor

- [x] If documentation is needed for this change, has that been included in this pull request
- [x] run `npm run lint` and fix any linting issues that have been introduced
- [x] run `npm run test` and run tests
