### PR TITLE
test: use vitest for test type checking

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "type-check": "tsc --noEmit",
     "bot:build": "tsc ./src/bot/index.ts --noEmit false --esModuleInterop --outDir ./build",
     "bot:start": "probot run ./build/index.js",
-    "test": "npm run type-check && TEST_LOGGING=1 vitest run",
+    "test": "TEST_LOGGING=1 vitest run",
     "test:watch": "TEST_LOGGING=1 vitest",
     "test:coverage": "TEST_LOGGING=1 vitest run --coverage",
     "prepare": "husky || true"

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -22,5 +22,11 @@ export default defineConfig({
         'build/**',
       ],
     },
+    typecheck: {
+      enabled: true,
+      checker: 'tsc',
+      include: ['test/**/*.ts'],
+      tsconfig: './tsconfig.json',
+    },
   },
 })


### PR DESCRIPTION
# Pull Request

## Proposed Changes

Use Vitest to check types for tests, instead of using `tsc` separately. Follow-on to #436, #454.

I validated that a type error will fail tests.
<img width="1321" height="177" alt="image" src="https://github.com/user-attachments/assets/a2a7dfd8-08bc-4676-b6db-0cd163b8c028" />

Note that adding type checking adds ~3.5s on to total test execution time on my machine, raising the total time from ~6.5s to ~10s. In the future, updating to TypeScript 7, rewritten in Go with significantly faster performance, should bring the test time back down.
<img width="2203" height="275" alt="image" src="https://github.com/user-attachments/assets/bc383b01-87e2-4971-aef5-d2c13887c8ce" />

Co-authored-by: Copilot <copilot@github.com>

## Readiness Checklist

### Author/Contributor

- [x] If documentation is needed for this change, has that been included in this pull request
- [x] run `npm run format` and fix any formatting issues that have been introduced
- [x] run `npm run lint` and fix any linting issues that have been introduced
- [x] run `npm run test` and run tests
