### PR TITLE
chore: add test coverage thresholds

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -35,3 +35,25 @@ jobs:
 
       - name: Run Tests
         run: npm test
+
+  coverage:
+    name: Coverage
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+
+      - name: Setup Node.js
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
+        with:
+          node-version: 22
+          cache: 'npm'
+
+      - name: Install Dependencies
+        run: npm ci --ignore-scripts
+
+      - name: Run Coverage
+        run: npm run test:coverage

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -34,26 +34,4 @@ jobs:
         run: npm ci --ignore-scripts
 
       - name: Run Tests
-        run: npm test
-
-  coverage:
-    name: Coverage
-    runs-on: ubuntu-latest
-
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-        with:
-          persist-credentials: false
-
-      - name: Setup Node.js
-        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
-        with:
-          node-version: 22
-          cache: 'npm'
-
-      - name: Install Dependencies
-        run: npm ci --ignore-scripts
-
-      - name: Run Coverage
         run: npm run test:coverage

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -21,6 +21,12 @@ export default defineConfig({
         '.next/**',
         'build/**',
       ],
+      thresholds: {
+        lines: 45,
+        functions: 35,
+        branches: 35,
+        statements: 45,
+      },
     },
     typecheck: {
       enabled: true,


### PR DESCRIPTION
# Pull Request
This PR will add coverage thresholds for tests based on the current coverage output numbers to make sure any new additions don't reduce the current coverage. 

In future work the coverage will be increased for the repo as a whole and the threshold will be increased to 80.

## Proposed Changes
Updated:
- .github workflow for test to allow for coverage check
- added coverage threhold to vitest config set to slightly under current coverage

Closes #459 

## Readiness Checklist

### Author/Contributor

- [x] If documentation is needed for this change, has that been included in this pull request
- [x] run `npm run format` and fix any formatting issues that have been introduced
- [x] run `npm run lint` and fix any linting issues that have been introduced
- [x] run `npm run test` and run tests
