### PR TITLE
test: streamline vitest scripts with coverage

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -34,4 +34,4 @@ jobs:
         run: npm ci --ignore-scripts
 
       - name: Run Tests
-        run: npm run test:coverage
+        run: npm run test

--- a/package.json
+++ b/package.json
@@ -18,9 +18,8 @@
     "type-check": "tsc --noEmit",
     "bot:build": "tsc ./src/bot/index.ts --noEmit false --esModuleInterop --outDir ./build",
     "bot:start": "probot run ./build/index.js",
-    "test": "TEST_LOGGING=1 vitest run",
-    "test:watch": "TEST_LOGGING=1 vitest",
-    "test:coverage": "TEST_LOGGING=1 vitest run --coverage",
+    "test": "TEST_LOGGING=1 vitest run --coverage",
+    "test:watch": "TEST_LOGGING=1 vitest --coverage",
     "prepare": "husky || true"
   },
   "dependencies": {


### PR DESCRIPTION
## Summary

Combine scripts for Vitest testing and always run with coverage enabled. Addressed feedback from https://github.com/github-community-projects/private-mirrors/pull/463#pullrequestreview-4215760762.

Note that the Husky pre-push hook already runs `npm test`, so coverage will now be enforced on pre-push.

### Open questions

1. Need to test whether or not coverage works in watch mode
2. Alternatively, could enable coverage in vitest config by setting `enabled: true` (see https://vitest.dev/guide/coverage.html#coverage-setup); I'm open to either approach