### PR TITLE
fix: remove unneeded git hooks config

### DIFF
--- a/src/server/git/controller.ts
+++ b/src/server/git/controller.ts
@@ -59,8 +59,6 @@ export const syncReposHandler = async ({
       config: [
         `user.name=pma[bot]`,
         `user.email=${input.source.octokit.installationId}+pma[bot]@users.noreply.github.com`,
-        // Disable any global git hooks to prevent potential interference when running the app locally
-        'core.hooksPath=/dev/null',
       ],
     }
 

--- a/src/server/git/controller.ts
+++ b/src/server/git/controller.ts
@@ -127,7 +127,7 @@ export const syncReposHandler = async ({
           )
 
           // Push this back to the source branch to retrigger the sync
-          await git.push(['--force'])
+          await git.push(['--no-verify', '--force'])
 
           // Return to end function call
           return {
@@ -145,12 +145,12 @@ export const syncReposHandler = async ({
     gitApiLogger.debug('Checked out branch', input.destination.branch)
 
     // Fast Forward merge the source branch on top of the destination branch
-    await git.merge(['--ff-only', input.source.branch]) // shouldn't fail because of check above, but nothing done to handle a failure
+    await git.merge(['--no-verify', '--ff-only', input.source.branch]) // shouldn't fail because of check above, but nothing done to handle a failure
     gitApiLogger.debug(
       `Merged source branch: ${input.source.branch} into destination branch: ${input.destination.branch} using fast forward`,
     )
 
-    await git.push(['--force'])
+    await git.push(['--no-verify', '--force'])
 
     gitApiLogger.debug(
       `Pushed to ${input.destination.org}/${input.destination.repo}/${input.destination.branch}`,

--- a/src/server/repos/controller.ts
+++ b/src/server/repos/controller.ts
@@ -147,11 +147,11 @@ export const createMirrorHandler = async ({
       newRepo.data.name,
     )
     await git.addRemote('upstream', upstreamRemote)
-    await git.push('upstream', defaultBranch)
+    await git.push(['--no-verify', 'upstream', defaultBranch])
 
     // Create a new branch on both
     await git.checkoutBranch(input.newBranchName, defaultBranch)
-    await git.push('origin', input.newBranchName)
+    await git.push(['--no-verify', 'origin', input.newBranchName])
 
     reposApiLogger.info('Mirror created', {
       org: newRepo.data.owner.login,

--- a/src/server/repos/controller.ts
+++ b/src/server/repos/controller.ts
@@ -94,8 +94,6 @@ export const createMirrorHandler = async ({
         `user.name=pma[bot]`,
         // We want to use the private installation ID as the email so that we can push to the private repo
         `user.email=${privateInstallationId}+pma[bot]@users.noreply.github.com`,
-        // Disable any global git hooks to prevent potential interference when running the app locally
-        'core.hooksPath=/dev/null',
       ],
     }
     const git = simpleGit(tempDir, options)

--- a/test/server/git/controller.test.ts
+++ b/test/server/git/controller.test.ts
@@ -187,9 +187,13 @@ describe('Git controller', () => {
       'destination/destinationBranch',
     )
     expect(gitMock.merge).toHaveBeenCalledTimes(1)
-    expect(gitMock.merge).toHaveBeenCalledWith(['--ff-only', 'sourceBranch'])
+    expect(gitMock.merge).toHaveBeenCalledWith([
+      '--no-verify',
+      '--ff-only',
+      'sourceBranch',
+    ])
     expect(gitMock.push).toHaveBeenCalledTimes(1)
-    expect(gitMock.push).toHaveBeenCalledWith(['--force'])
+    expect(gitMock.push).toHaveBeenCalledWith(['--no-verify', '--force'])
   })
 
   it('should be syncable, have the environment flag set to true, but not be a merge commit', async () => {
@@ -265,9 +269,13 @@ describe('Git controller', () => {
       'destination/destinationBranch',
     )
     expect(gitMock.merge).toHaveBeenCalledTimes(1)
-    expect(gitMock.merge).toHaveBeenCalledWith(['--ff-only', 'sourceBranch'])
+    expect(gitMock.merge).toHaveBeenCalledWith([
+      '--no-verify',
+      '--ff-only',
+      'sourceBranch',
+    ])
     expect(gitMock.push).toHaveBeenCalledTimes(1)
-    expect(gitMock.push).toHaveBeenCalledWith(['--force'])
+    expect(gitMock.push).toHaveBeenCalledWith(['--no-verify', '--force'])
   })
 
   it('should be syncable, have the environment flag set to true, be a merge commit, but not be a merge to main branch', async () => {
@@ -348,9 +356,13 @@ describe('Git controller', () => {
       'destination/destinationBranch',
     )
     expect(gitMock.merge).toHaveBeenCalledTimes(1)
-    expect(gitMock.merge).toHaveBeenCalledWith(['--ff-only', 'sourceBranch'])
+    expect(gitMock.merge).toHaveBeenCalledWith([
+      '--no-verify',
+      '--ff-only',
+      'sourceBranch',
+    ])
     expect(gitMock.push).toHaveBeenCalledTimes(1)
-    expect(gitMock.push).toHaveBeenCalledWith(['--force'])
+    expect(gitMock.push).toHaveBeenCalledWith(['--no-verify', '--force'])
   })
 
   it('should be syncable, have the environment flag set to true, be a merge commit, and be a merge to main branch,', async () => {
@@ -429,6 +441,6 @@ describe('Git controller', () => {
     expect(gitMock.reset).toHaveBeenCalledTimes(1)
     expect(gitMock.reset).toHaveBeenCalledWith(['--hard', 'HEAD^2'])
     expect(gitMock.push).toHaveBeenCalledTimes(1)
-    expect(gitMock.push).toHaveBeenCalledWith(['--force'])
+    expect(gitMock.push).toHaveBeenCalledWith(['--no-verify', '--force'])
   })
 })


### PR DESCRIPTION
# Pull Request

## Proposed Changes

Addresses https://github.com/github-community-projects/private-mirrors/pull/469#issuecomment-4409398002.

#469 updated `simple-git` from 3.32.3 to 3.36.0. In v3.33.0 ([steveukx/git-js#1135](https://github.com/steveukx/git-js/pull/1135)). The library's `blockUnsafeOperationsPlugin` began blocking `core.hooksPath` configuration by default, throwing a `GitPluginError` at runtime. Both `src/server/git/controller.ts` and `src/server/repos/controller.ts` used `core.hooksPath=/dev/null` to disable hooks, which then broke at runtime.

### Fix

Remove `core.hooksPath=/dev/null` entirely rather than opting into `unsafe: { allowUnsafeHooksPath: true }`.

### Why removal is safe

- **Temp directories don't inherit hooks**: Both controllers operate in fresh temp directories (via `tempy.directory()`). `git init` and `git clone` create isolated `.git/config` files with no `hooksPath` setting.
- **Husky is local-only**: The project's husky config (`core.hooksPath = .husky/_`) is set in the project's local `.git/config`, not globally. It does not propagate to other repos.
- **Cloned repos can't inject hooks**: Git hooks live in `.git/hooks/` (local metadata), never transferred during clone. GitHub-hosted repos cannot include active hooks that execute on the cloning machine.
- **Other operations unaffected**: `git.reset(['--hard', ...])`, `git.push(['--force'])`, and `git.raw(['merge-base', ...])` are not blocked — the plugin only targets config-injection attack vectors, not git operations themselves.

### Edge cases (not a concern)

- **Developer with global `core.hooksPath` in `~/.gitconfig`**: Hooks would fire in temp directories during local development. This is uncommon (husky v9 never sets global config), only affects local dev (not production/CI), and the developer would immediately notice hook failures.
- **`GIT_DIR` environment variable leakage**: If the Node.js process inherited `GIT_DIR` pointing to the project's `.git/`, the project's local `hooksPath` could leak into temp directory operations. This doesn't happen in normal execution — the app is not launched from within a git hook or script that sets `GIT_DIR`.

## Readiness Checklist

### Author/Contributor

- [x] ~~If documentation is needed for this change, has that been included in this pull request~~
- [x] run `npm run format` and fix any formatting issues that have been introduced
- [x] run `npm run lint` and fix any linting issues that have been introduced
- [x] run `npm run test` and run tests
