### PR TITLE
chore: bump ospo-reusable-workflows release.yaml to v1.0.1

### DIFF
--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -8,6 +8,9 @@ template: |
   See details of [all code changes](https://github.com/$OWNER/$REPOSITORY/compare/$PREVIOUS_TAG...v$RESOLVED_VERSION) since previous release
 
 categories:
+  - title: '💥 Breaking Changes'
+    labels:
+      - 'breaking'
   - title: '🚀 Features'
     labels:
       - 'feature'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,24 +17,14 @@ jobs:
     permissions:
       contents: write
       pull-requests: read
-    uses: github-community-projects/ospo-reusable-workflows/.github/workflows/release.yaml@6f158f242fe68adb5a2698ef47e06dac07ac7e71
-    with:
-      publish: true
-      release-config-name: release-drafter.yml
-    secrets:
-      github-token: ${{ secrets.GITHUB_TOKEN }}
-  release_image:
-    needs: release
-    permissions:
-      contents: read
       packages: write
       id-token: write
       attestations: write
-    uses: github-community-projects/ospo-reusable-workflows/.github/workflows/release-image.yaml@6f158f242fe68adb5a2698ef47e06dac07ac7e71
+    uses: github-community-projects/ospo-reusable-workflows/.github/workflows/release.yaml@592067a69a43d2285f933753d89a7c9d51b96530 # v1.0.0
     with:
+      publish: true
+      release-config-name: release-drafter.yml
       image-name: ${{ github.repository }}
-      full-tag: ${{ needs.release.outputs.full-tag }}
-      short-tag: ${{ needs.release.outputs.short-tag }}
       create-attestation: true
     secrets:
       github-token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,11 +15,12 @@ permissions:
 jobs:
   release:
     permissions:
-      contents: write
-      pull-requests: read
-      packages: write
-      id-token: write
-      attestations: write
+      contents: write       # Create release and push tags
+      pull-requests: read   # Read PR labels for release-drafter
+      packages: write       # Push container image to ghcr.io
+      id-token: write       # Federate for artifact attestation
+      attestations: write   # Generate build provenance attestations
+      discussions: write    # Create release announcement discussion
     uses: github-community-projects/ospo-reusable-workflows/.github/workflows/release.yaml@592067a69a43d2285f933753d89a7c9d51b96530 # v1.0.0
     with:
       publish: true

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -21,7 +21,7 @@ jobs:
       id-token: write # Federate for artifact attestation
       attestations: write # Generate build provenance attestations
       discussions: write # Create release announcement discussion
-    uses: github-community-projects/ospo-reusable-workflows/.github/workflows/release.yaml@592067a69a43d2285f933753d89a7c9d51b96530 # v1.0.0
+    uses: github-community-projects/ospo-reusable-workflows/.github/workflows/release.yaml@e92cb6053ace495fe40a5f185988557afcdcecbc # v1.0.1
     with:
       publish: true
       release-config-name: release-drafter.yml

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,12 +15,12 @@ permissions:
 jobs:
   release:
     permissions:
-      contents: write       # Create release and push tags
-      pull-requests: read   # Read PR labels for release-drafter
-      packages: write       # Push container image to ghcr.io
-      id-token: write       # Federate for artifact attestation
-      attestations: write   # Generate build provenance attestations
-      discussions: write    # Create release announcement discussion
+      contents: write # Create release and push tags
+      pull-requests: read # Read PR labels for release-drafter
+      packages: write # Push container image to ghcr.io
+      id-token: write # Federate for artifact attestation
+      attestations: write # Generate build provenance attestations
+      discussions: write # Create release announcement discussion
     uses: github-community-projects/ospo-reusable-workflows/.github/workflows/release.yaml@592067a69a43d2285f933753d89a7c9d51b96530 # v1.0.0
     with:
       publish: true


### PR DESCRIPTION
## Proposed Changes

### What

Pin the reusable release workflow to v1.0.0 (SHA 592067a69a43d2285f933753d89a7c9d51b96530). Add a Breaking Changes category to release-drafter.

### Why

v1.0.0 of ospo-reusable-workflows broadens the release trigger to include breaking, feature, vuln, and release labels and folds GoReleaser, container image build, attestation, and discussion creation into the reusable workflow itself. Surfacing breaking changes prominently in release notes aligns the changelog with the new label-based release triggers.

### Notes

- The previously separate `release_image` job has been collapsed into the single `release` call by passing `image-name` and `create-attestation: true`, since v1.0.0 of the reusable workflow handles container image build and attestation internally.
- Image registry secrets (`image-registry`, `image-registry-username`, `image-registry-password`) and the `packages`, `id-token`, `attestations` permissions are now consolidated onto the `release` job.
- Trigger already uses `pull_request_target`, so no trigger change was needed.

### Testing

After merging, trigger the release workflow via workflow_dispatch from the Actions tab, or merge a future PR labeled `release`/`feature`/`breaking`/`vuln` to validate end-to-end.

## Readiness Checklist

### Author/Contributor

- [x] If documentation is needed for this change, has that been included in this pull request
- [x] run `npm run format` and fix any formatting issues that have been introduced
- [x] run `npm run lint` and fix any linting issues that have been introduced
- [x] run `npm run test` and run tests