### PR TITLE
fix(release): move image-registry and image-registry-username to inputs

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -26,8 +26,6 @@ jobs:
       publish: true
       release-config-name: release-drafter.yml
       image-name: ${{ github.repository }}
-      image-registry: ghcr.io
-      image-registry-username: ${{ github.actor }}
       create-attestation: true
     secrets:
       github-token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -26,9 +26,9 @@ jobs:
       publish: true
       release-config-name: release-drafter.yml
       image-name: ${{ github.repository }}
+      image-registry: ghcr.io
+      image-registry-username: ${{ github.actor }}
       create-attestation: true
     secrets:
       github-token: ${{ secrets.GITHUB_TOKEN }}
-      image-registry: ghcr.io
-      image-registry-username: ${{ github.actor }}
       image-registry-password: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## What

Remove `image-registry` and `image-registry-username` from the release job's call to `ospo-reusable-workflows/release.yaml` entirely, and keep only `image-registry-password` in the `secrets:` block.

## Why

In v1.0+ of the consolidated release reusable workflow, only `image-registry-password` is declared as a secret. `image-registry` and `image-registry-username` are declared as workflow **inputs** with defaults of `ghcr.io` and `github.actor` — the exact values this repo was passing. Passing unknown secrets to a reusable workflow causes GitHub Actions to reject the run with `startup_failure` before any job executes. PR #471's merge triggered exactly this failure: https://github.com/github-community-projects/private-mirrors/actions/runs/25645109482

Aligning with the canonical caller `github-community-projects/issue-metrics`, the cleanest fix is to omit both fields and rely on the defaults.

## Notes

- Carryover from the pre-v1.0 `release-image.yaml` reusable workflow where all four `image-registry-*` parameters were secrets. The v1.0 consolidation reclassified the non-sensitive ones as inputs.
- Behavior is unchanged: `image-registry` still resolves to `ghcr.io`, `image-registry-username` still resolves to `github.actor`.
- The branch contains two commits showing the progression (first move-to-inputs, then drop-redundant). Happy to squash on request.

## Testing

After merging, the next merged PR with a release-triggering label will start the Release workflow successfully (no `startup_failure` on secret-name validation).