### PR TITLE
fix: issues with creating mirrors for large repos

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -39,3 +39,6 @@ DELETE_INTERNAL_MERGE_COMMITS_ON_SYNC=
 
 # Used to configure the timeout for syncing a mirror before the task gets backgrounded (default is 30 seconds)
 MIRROR_SYNC_TIMEOUT_MS=
+
+# Used to configure the number of commits to push at a time when syncing a mirror (default is 100)
+MIRROR_PUSH_CHUNK_SIZE=

--- a/.env.example
+++ b/.env.example
@@ -36,3 +36,6 @@ CREATE_MIRRORS_WITH_INTERNAL_VISIBILITY=
 
 # Used for syncing logic to avoid having EMU users listed as committer
 DELETE_INTERNAL_MERGE_COMMITS_ON_SYNC=
+
+# Used to configure the timeout for syncing a mirror before the task gets backgrounded (default is 30 seconds)
+MIRROR_SYNC_TIMEOUT_MS=

--- a/env.mjs
+++ b/env.mjs
@@ -73,6 +73,25 @@ export const env = createEnv({
         }
         return parsed
       }),
+    MIRROR_PUSH_CHUNK_SIZE: z
+      .string()
+      .optional()
+      .default('1000')
+      .transform((value, ctx) => {
+        const parsed = Number(value)
+        if (
+          !Number.isFinite(parsed) ||
+          !Number.isInteger(parsed) ||
+          parsed <= 0
+        ) {
+          ctx.addIssue({
+            code: z.ZodIssueCode.custom,
+            message: 'MIRROR_PUSH_CHUNK_SIZE must be a positive integer',
+          })
+          return z.NEVER
+        }
+        return parsed
+      }),
   },
   /*
    * Environment variables available on the client (and server).
@@ -107,6 +126,7 @@ export const env = createEnv({
     DELETE_INTERNAL_MERGE_COMMITS_ON_SYNC:
       process.env.DELETE_INTERNAL_MERGE_COMMITS_ON_SYNC,
     MIRROR_SYNC_TIMEOUT_MS: process.env.MIRROR_SYNC_TIMEOUT_MS,
+    MIRROR_PUSH_CHUNK_SIZE: process.env.MIRROR_PUSH_CHUNK_SIZE,
   },
   skipValidation: process.env.SKIP_ENV_VALIDATIONS === 'true',
 })

--- a/env.mjs
+++ b/env.mjs
@@ -54,6 +54,25 @@ export const env = createEnv({
       .optional()
       .default('false')
       .transform((value) => value === 'true'),
+    MIRROR_SYNC_TIMEOUT_MS: z
+      .string()
+      .optional()
+      .default('30000')
+      .transform((value, ctx) => {
+        const parsed = Number(value)
+        if (
+          !Number.isFinite(parsed) ||
+          !Number.isInteger(parsed) ||
+          parsed <= 0
+        ) {
+          ctx.addIssue({
+            code: z.ZodIssueCode.custom,
+            message: 'MIRROR_SYNC_TIMEOUT_MS must be a positive integer',
+          })
+          return z.NEVER
+        }
+        return parsed
+      }),
   },
   /*
    * Environment variables available on the client (and server).
@@ -87,6 +106,7 @@ export const env = createEnv({
       process.env.CREATE_MIRRORS_WITH_INTERNAL_VISIBILITY,
     DELETE_INTERNAL_MERGE_COMMITS_ON_SYNC:
       process.env.DELETE_INTERNAL_MERGE_COMMITS_ON_SYNC,
+    MIRROR_SYNC_TIMEOUT_MS: process.env.MIRROR_SYNC_TIMEOUT_MS,
   },
   skipValidation: process.env.SKIP_ENV_VALIDATIONS === 'true',
 })

--- a/src/app/[organizationId]/forks/[forkId]/page.tsx
+++ b/src/app/[organizationId]/forks/[forkId]/page.tsx
@@ -26,6 +26,7 @@ import { DeleteMirrorDialog } from 'app/components/dialog/DeleteMirrorDialog'
 import { EditMirrorDialog } from 'app/components/dialog/EditMirrorDialog'
 import { AppNotInstalledFlash } from 'app/components/flash/AppNotInstalledFlash'
 import { ErrorFlash } from 'app/components/flash/ErrorFlash'
+import { PendingFlash } from 'app/components/flash/PendingFlash'
 import { SuccessFlash } from 'app/components/flash/SuccessFlash'
 import { ForkHeader } from 'app/components/header/ForkHeader'
 import { Loading } from 'app/components/loading/Loading'
@@ -120,6 +121,17 @@ const Fork = () => {
     [setIsCreateSuccessFlashOpen],
   )
 
+  const [isCreatePendingFlashOpen, setIsCreatePendingFlashOpen] =
+    useState(false)
+  const closeCreatePendingFlash = useCallback(
+    () => setIsCreatePendingFlashOpen(false),
+    [setIsCreatePendingFlashOpen],
+  )
+  const openCreatePendingFlash = useCallback(
+    () => setIsCreatePendingFlashOpen(true),
+    [setIsCreatePendingFlashOpen],
+  )
+
   const [isEditSuccessFlashOpen, setIsEditSuccessFlashOpen] = useState(false)
   const closeEditSuccessFlash = useCallback(
     () => setIsEditSuccessFlashOpen(false),
@@ -133,12 +145,14 @@ const Fork = () => {
   const closeAllFlashes = useCallback(() => {
     closeCreateErrorFlash()
     closeCreateSuccessFlash()
+    closeCreatePendingFlash()
     closeEditErrorFlash()
     closeEditSuccessFlash()
     closeDeleteErrorFlash()
   }, [
     closeCreateErrorFlash,
     closeCreateSuccessFlash,
+    closeCreatePendingFlash,
     closeEditErrorFlash,
     closeEditSuccessFlash,
     closeDeleteErrorFlash,
@@ -213,7 +227,11 @@ const Fork = () => {
       })
         .then((res) => {
           if (res.success) {
-            openCreateSuccessFlash()
+            if (res.pending) {
+              openCreatePendingFlash()
+            } else {
+              openCreateSuccessFlash()
+            }
           }
         })
         .catch((error) => {
@@ -229,6 +247,7 @@ const Fork = () => {
       createMirror,
       refetchMirrors,
       openCreateSuccessFlash,
+      openCreatePendingFlash,
       openCreateErrorFlash,
       orgData,
       forkData,
@@ -307,6 +326,40 @@ const Fork = () => {
     ],
   )
 
+  // Rendered identically in both the empty-state and populated branches below.
+  // Extracted so any change to flash rendering only needs to be made once.
+  const createMirrorFlashes = (
+    <>
+      <Box sx={{ marginBottom: '10px' }}>
+        {createMirrorData &&
+          createMirrorData.success &&
+          !createMirrorData.pending &&
+          isCreateSuccessFlashOpen && (
+            <SuccessFlash
+              message="You have successfully created a new private mirror at"
+              closeFlash={closeCreateSuccessFlash}
+              mirrorName={createMirrorData.data?.name}
+              mirrorUrl={createMirrorData.data?.html_url}
+              orgLogin={createMirrorData.data?.owner.login}
+            />
+          )}
+      </Box>
+      <Box sx={{ marginBottom: '10px' }}>
+        {createMirrorData &&
+          createMirrorData.success &&
+          createMirrorData.pending &&
+          isCreatePendingFlashOpen && (
+            <PendingFlash
+              closeFlash={closeCreatePendingFlash}
+              mirrorName={createMirrorData.data?.name}
+              mirrorUrl={createMirrorData.data?.html_url}
+              orgLogin={createMirrorData.data?.owner.login}
+            />
+          )}
+      </Box>
+    </>
+  )
+
   // show loading table
   if (mirrorsLoading || configLoading) {
     return (
@@ -376,19 +429,7 @@ const Fork = () => {
             />
           )}
         </Box>
-        <Box sx={{ marginBottom: '10px' }}>
-          {createMirrorData &&
-            createMirrorData.success &&
-            isCreateSuccessFlashOpen && (
-              <SuccessFlash
-                message="You have successfully created a new private mirror at"
-                closeFlash={closeCreateSuccessFlash}
-                mirrorName={createMirrorData.data?.name}
-                mirrorUrl={createMirrorData.data?.html_url}
-                orgLogin={createMirrorData.data?.owner.login}
-              />
-            )}
-        </Box>
+        {createMirrorFlashes}
         <ForkBreadcrumbs orgData={orgData.data} forkData={forkData.data} />
         <SearchWithCreate
           placeholder="Find a mirror"
@@ -501,19 +542,7 @@ const Fork = () => {
           />
         )}
       </Box>
-      <Box sx={{ marginBottom: '10px' }}>
-        {createMirrorData &&
-          createMirrorData.success &&
-          isCreateSuccessFlashOpen && (
-            <SuccessFlash
-              message="You have successfully created a new private mirror at"
-              closeFlash={closeCreateSuccessFlash}
-              mirrorName={createMirrorData.data?.name}
-              mirrorUrl={createMirrorData.data?.html_url}
-              orgLogin={createMirrorData.data?.owner.login}
-            />
-          )}
-      </Box>
+      {createMirrorFlashes}
       <Box sx={{ marginBottom: '10px' }}>
         {editMirrorData && editMirrorData.success && isEditSuccessFlashOpen && (
           <SuccessFlash

--- a/src/app/[organizationId]/forks/[forkId]/page.tsx
+++ b/src/app/[organizationId]/forks/[forkId]/page.tsx
@@ -199,20 +199,13 @@ const Fork = () => {
   } = trpc.deleteMirror.useMutation()
 
   const handleOnCreateMirror = useCallback(
-    async ({
-      repoName,
-      branchName,
-    }: {
-      repoName: string
-      branchName: string
-    }) => {
+    async ({ repoName }: { repoName: string }) => {
       // close other flashes and dialogs when this is opened
       closeAllFlashes()
       closeCreateDialog()
 
       await createMirror({
         newRepoName: repoName,
-        newBranchName: branchName,
         orgId: String(orgData?.data?.id),
         forkRepoName: forkData?.data?.name ?? '',
         forkRepoOwner: forkData?.data?.owner.login ?? '',

--- a/src/app/components/dialog/CreateMirrorDialog.tsx
+++ b/src/app/components/dialog/CreateMirrorDialog.tsx
@@ -20,7 +20,7 @@ interface CreateMirrorDialogProps {
   forkParentName: string
   isOpen: boolean
   closeDialog: () => void
-  createMirror: (data: { repoName: string; branchName: string }) => void
+  createMirror: (data: { repoName: string }) => void
 }
 
 export const CreateMirrorDialog = ({
@@ -61,7 +61,7 @@ export const CreateMirrorDialog = ({
           content: 'Confirm',
           variant: 'primary',
           onClick: () => {
-            createMirror({ repoName, branchName: repoName })
+            createMirror({ repoName })
             setRepoName(DEFAULT_REPO_NAME)
           },
           disabled: !hasUserInput || !validation.success,

--- a/src/app/components/flash/PendingFlash.tsx
+++ b/src/app/components/flash/PendingFlash.tsx
@@ -1,0 +1,53 @@
+import { ClockIcon, XIcon } from '@primer/octicons-react'
+import { Box, Flash, IconButton, Link, Octicon } from '@primer/react'
+
+interface PendingFlashProps {
+  mirrorUrl: string
+  orgLogin: string
+  mirrorName: string
+  closeFlash: () => void
+}
+
+export const PendingFlash = ({
+  mirrorUrl,
+  orgLogin,
+  mirrorName,
+  closeFlash,
+}: PendingFlashProps) => {
+  return (
+    <Flash variant="warning">
+      <Box
+        sx={{
+          display: 'flex',
+          flexDirection: 'row',
+          alignItems: 'center',
+        }}
+      >
+        <Box>
+          <Octicon icon={ClockIcon}></Octicon>
+        </Box>
+        <Box sx={{ marginLeft: '20px' }}>
+          Mirror creation is taking longer than expected and will continue in
+          the background. Your new private mirror{' '}
+          <Link href={mirrorUrl} target="_blank" rel="noreferrer noopener">
+            {orgLogin}/{mirrorName}
+          </Link>{' '}
+          may take some time to be fully populated with commits.
+        </Box>
+        <Box
+          sx={{
+            marginLeft: 'auto',
+          }}
+        >
+          <IconButton
+            icon={XIcon}
+            variant="invisible"
+            aria-labelledby="dismiss create pending"
+            onClick={closeFlash}
+            size="small"
+          />
+        </Box>
+      </Box>
+    </Flash>
+  )
+}

--- a/src/server/repos/controller.ts
+++ b/src/server/repos/controller.ts
@@ -226,13 +226,78 @@ export const createMirrorHandler = async ({
     }
     const git = simpleGit(tempDir, options)
 
-    // Create a clone of the fork that contains only what is necessary to push to the mirror
-    const cloneConfig = ['--single-branch', '--branch', branch, '--no-tags']
-    await git.clone(forkRemote, tempDir, cloneConfig)
+    // Run the slow git work (clone + push) with a timeout. If execution exceeds
+    // MIRROR_SYNC_TIMEOUT_MS we return a pending response and let the work
+    // continue in the background.
+    const gitWork = (async () => {
+      // Create a clone of the fork that contains only what is necessary to push to the mirror
+      const cloneConfig = ['--single-branch', '--branch', branch, '--no-tags']
+      await git.clone(forkRemote, tempDir, cloneConfig)
 
-    // Push the commits from cloned source up to the newly created mirror
-    await git.addRemote('mirror', mirrorRemote)
-    await git.push(['--no-verify', 'mirror', branch])
+      // Push the commits from cloned source up to the newly created mirror
+      await git.addRemote('mirror', mirrorRemote)
+      await git.push(['--no-verify', 'mirror', branch])
+    })()
+
+    const MIRROR_SYNC_TIMEOUT_MS = Number(
+      process.env.MIRROR_SYNC_TIMEOUT_MS ?? 30_000,
+    )
+
+    // Sentinel returned by the timeout branch of Promise.race so the pending path
+    // is distinguishable from a resolved git promise without throw/catch.
+    const PENDING_SENTINEL: unique symbol = Symbol('pending')
+
+    let timer: ReturnType<typeof setTimeout> | undefined
+    const timeoutPromise = new Promise<typeof PENDING_SENTINEL>((resolve) => {
+      timer = setTimeout(
+        () => resolve(PENDING_SENTINEL),
+        MIRROR_SYNC_TIMEOUT_MS,
+      )
+    })
+
+    const raceResult = await Promise.race([gitWork, timeoutPromise])
+
+    if (raceResult === PENDING_SENTINEL) {
+      reposApiLogger.info(
+        'Mirror creation exceeded sync window; continuing in background',
+        {
+          repo: mirrorRepo?.data.name,
+          timeoutMs: MIRROR_SYNC_TIMEOUT_MS,
+        },
+      )
+
+      // Attaching handlers here is required — without them a later rejection
+      // would surface as an unhandled promise rejection.
+      gitWork
+        .then(() =>
+          reposApiLogger.info('Background mirror creation completed', {
+            repo: mirrorRepo?.data.name,
+          }),
+        )
+        .catch(async (err) => {
+          reposApiLogger.error('Background mirror creation failed', {
+            error: err,
+            repo: mirrorRepo?.data.name,
+          })
+          await deleteMirrorAndSyncBranch({
+            privateOctokit,
+            mirrorRepoRef: mirrorRepo && {
+              owner: mirrorRepo.data.owner.login,
+              name: input.newRepoName,
+            },
+            publicOctokit,
+            syncBranchRef,
+          })
+        })
+
+      return {
+        success: true,
+        pending: true,
+        data: mirrorRepo.data,
+      }
+    }
+
+    clearTimeout(timer)
 
     reposApiLogger.info('Mirror created', {
       org: mirrorRepo.data.owner.login,
@@ -241,6 +306,7 @@ export const createMirrorHandler = async ({
 
     return {
       success: true,
+      pending: false,
       data: mirrorRepo.data,
     }
   } catch (error) {

--- a/src/server/repos/controller.ts
+++ b/src/server/repos/controller.ts
@@ -234,8 +234,30 @@ export const createMirrorHandler = async ({
       const cloneConfig = ['--single-branch', '--branch', branch, '--no-tags']
       await git.clone(forkRemote, tempDir, cloneConfig)
 
-      // Push the commits from cloned source up to the newly created mirror
       await git.addRemote('mirror', mirrorRemote)
+
+      // Push commits in chunks so that large pushes don't encounter timeout issues
+      const chunkSize = Number(process.env.MIRROR_PUSH_CHUNK_SIZE ?? 1000)
+      const commitCount = Number(
+        (await git.raw(['rev-list', '--count', branch])).trim(),
+      )
+
+      for (let chunk = 1; chunk * chunkSize < commitCount; chunk++) {
+        // Get the sha for the end of the next chunk of commits to push
+        const sha = (
+          await git.raw([
+            'rev-list',
+            '--reverse',
+            `--skip=${chunk * chunkSize - 1}`,
+            '--max-count=1',
+            branch,
+          ])
+        ).trim()
+
+        await git.push(['--no-verify', 'mirror', `${sha}:refs/heads/${branch}`])
+      }
+
+      // Push up the branch tip and any remaining commits
       await git.push(['--no-verify', 'mirror', branch])
     })()
 

--- a/src/server/repos/controller.ts
+++ b/src/server/repos/controller.ts
@@ -9,6 +9,7 @@ import {
   getAuthenticatedOctokit,
   installationOctokit,
 } from '../../bot/octokit'
+import { Octokit } from '../../bot/rest'
 import { logger } from '../../utils/logger'
 import {
   CreateMirrorSchema,
@@ -20,6 +21,71 @@ import { TRPCError } from '@trpc/server'
 
 const reposApiLogger = logger.getSubLogger({ name: 'repos-api' })
 
+type MirrorRepo = Awaited<ReturnType<Octokit['rest']['repos']['createInOrg']>>
+type RepoRef = { owner: string; name: string }
+type SyncBranchRef = { owner: string; repo: string; branch: string }
+
+// Reads the `fork` custom property set at mirror-creation time and parses it
+// into { owner, name }. Returns undefined if the property is missing or
+// malformed
+const getForkRepoFromMirror = async (
+  octokit: Octokit,
+  mirrorOwner: string,
+  mirrorName: string,
+): Promise<RepoRef | undefined> => {
+  try {
+    const props = await octokit.rest.repos.getCustomPropertiesValues({
+      owner: mirrorOwner,
+      repo: mirrorName,
+    })
+    const forkProp = props.data.find((p) => p.property_name === 'fork')
+    if (!forkProp || typeof forkProp.value !== 'string') return undefined
+    const [owner, name] = forkProp.value.split('/')
+    if (!owner || !name) return undefined
+    return { owner, name }
+  } catch (error) {
+    reposApiLogger.error('Failed to read fork custom property', { error })
+    return undefined
+  }
+}
+
+// Deletes a private mirror repo and, when provided, the sync-destination
+// branch on the public fork.
+const deleteMirrorAndSyncBranch = async ({
+  privateOctokit,
+  mirrorRepoRef,
+  publicOctokit,
+  syncBranchRef,
+}: {
+  privateOctokit: Octokit | undefined
+  mirrorRepoRef: RepoRef | undefined
+  publicOctokit: Octokit | undefined
+  syncBranchRef: SyncBranchRef | undefined
+}) => {
+  if (privateOctokit && mirrorRepoRef) {
+    try {
+      await privateOctokit.rest.repos.delete({
+        owner: mirrorRepoRef.owner,
+        repo: mirrorRepoRef.name,
+      })
+    } catch (deleteError) {
+      reposApiLogger.error('Failed to delete mirror', { deleteError })
+    }
+  }
+
+  if (publicOctokit && syncBranchRef) {
+    try {
+      await publicOctokit.rest.git.deleteRef({
+        owner: syncBranchRef.owner,
+        repo: syncBranchRef.repo,
+        ref: `heads/${syncBranchRef.branch}`,
+      })
+    } catch (deleteError) {
+      reposApiLogger.error('Failed to delete sync branch ref', { deleteError })
+    }
+  }
+}
+
 // Creates a mirror of a forked repo
 export const createMirrorHandler = async ({
   input,
@@ -27,8 +93,10 @@ export const createMirrorHandler = async ({
   input: CreateMirrorSchema
 }) => {
   // Use to track mirror creation for cleanup in case of errors
-  let privateOctokit
-  let newRepo
+  let privateOctokit: Octokit | undefined
+  let publicOctokit: Octokit | undefined
+  let mirrorRepo: MirrorRepo | undefined
+  let syncBranchRef: SyncBranchRef | undefined
 
   try {
     reposApiLogger.info('createMirror', { input: input })
@@ -40,70 +108,66 @@ export const createMirrorHandler = async ({
     const { publicOrg, privateOrg } = config
 
     const octokitData = await getAuthenticatedOctokit(publicOrg, privateOrg)
-    const contributionOctokit = octokitData.contribution.octokit
-    const contributionAccessToken = octokitData.contribution.accessToken
+    publicOctokit = octokitData.contribution.octokit
+    const publicAccessToken = octokitData.contribution.accessToken
 
     privateOctokit = octokitData.private.octokit
     const privateInstallationId = octokitData.private.installationId
     const privateAccessToken = octokitData.private.accessToken
 
-    const orgData = await contributionOctokit.rest.orgs.get({
-      org: publicOrg,
-    })
-
-    await contributionOctokit.rest.repos
+    // Check if the desired repo name already exists in the private org before forking
+    const response = await privateOctokit.rest.repos
       .get({
-        owner: orgData.data.login,
+        owner: privateOrg,
         repo: input.newRepoName,
       })
-      .then((res) => {
-        // if we get a response, then we know the repo exists so we throw an error
-        if (res.status === 200) {
-          reposApiLogger.info(
-            `Repo ${orgData.data.login}/${input.newRepoName} already exists`,
-          )
-
-          throw new Error(
-            `Repo ${orgData.data.login}/${input.newRepoName} already exists`,
-          )
-        }
-      })
       .catch((error) => {
-        // catch and rethrow the error if the repo already exists
-        if ((error as Error).message.includes('already exists')) {
-          throw error
-        }
-
-        // if there is a real error, then we log it and throw it
+        // If there is an error other than "Not Found", log and throw it
         if (!(error as Error).message.includes('Not Found')) {
-          reposApiLogger.error('Not found', { error })
+          reposApiLogger.error(
+            `Searching for existing mirror named ${input.newRepoName} in ${privateOrg} failed with: `,
+            { error },
+          )
           throw error
         }
       })
 
-    const forkData = await contributionOctokit.rest.repos.get({
+    // If we get a response, the repo already exists so we should throw an error
+    if (response && response.status === 200) {
+      reposApiLogger.info(
+        `a mirror named ${input.newRepoName} already exists in ${privateOrg}`,
+      )
+
+      throw new Error(
+        `a mirror named ${input.newRepoName} already exists in ${privateOrg}`,
+      )
+    }
+
+    // TODO: replace this call with a passed in branch name as part of https://github.com/github-community-projects/private-mirrors/issues/448
+    const forkRepo = await publicOctokit.rest.repos.get({
       owner: input.forkRepoOwner,
       repo: input.forkRepoName,
     })
+    const branch = forkRepo.data.default_branch
 
-    // Now create a temporary directory to clone the repo into
-    const tempDir = temporaryDirectory()
-
-    const options: Partial<SimpleGitOptions> = {
-      config: [
-        `user.name=pma[bot]`,
-        // We want to use the private installation ID as the email so that we can push to the private repo
-        `user.email=${privateInstallationId}+pma[bot]@users.noreply.github.com`,
-      ],
+    // Create a sync destination branch on the public fork with the same name as the mirror
+    const sourceBranchRef = await publicOctokit.rest.git.getRef({
+      owner: input.forkRepoOwner,
+      repo: input.forkRepoName,
+      ref: `heads/${branch}`,
+    })
+    const sourceBranchSha = sourceBranchRef.data.object.sha
+    await publicOctokit.rest.git.createRef({
+      owner: input.forkRepoOwner,
+      repo: input.forkRepoName,
+      ref: `refs/heads/${input.newRepoName}`,
+      sha: sourceBranchSha,
+    })
+    syncBranchRef = {
+      owner: input.forkRepoOwner,
+      repo: input.forkRepoName,
+      branch: input.newRepoName,
     }
-    const git = simpleGit(tempDir, options)
-    const remote = generateAuthUrl(
-      contributionAccessToken,
-      input.forkRepoOwner,
-      input.forkRepoName,
-    )
-
-    await git.clone(remote, tempDir)
 
     // Get the organization custom properties
     const orgCustomProps =
@@ -124,8 +188,8 @@ export const createMirrorHandler = async ({
       })
     }
 
-    // This repo needs to be created in the private org
-    newRepo = await privateOctokit.rest.repos.createInOrg({
+    // Create the mirror repo in the private org
+    mirrorRepo = await privateOctokit.rest.repos.createInOrg({
       name: input.newRepoName,
       org: privateOrg,
       // @ts-expect-error because the rest API accepts internal as an option but the types aren't up to date
@@ -138,29 +202,46 @@ export const createMirrorHandler = async ({
       },
     })
 
-    const defaultBranch = forkData.data.default_branch
-
-    // Add the mirror remote
-    const upstreamRemote = generateAuthUrl(
-      privateAccessToken,
-      newRepo.data.owner.login,
-      newRepo.data.name,
+    const forkRemote = generateAuthUrl(
+      publicAccessToken,
+      input.forkRepoOwner,
+      input.forkRepoName,
     )
-    await git.addRemote('upstream', upstreamRemote)
-    await git.push(['--no-verify', 'upstream', defaultBranch])
 
-    // Create a new branch on both
-    await git.checkoutBranch(input.newRepoName, defaultBranch)
-    await git.push(['--no-verify', 'origin', input.newRepoName])
+    const mirrorRemote = generateAuthUrl(
+      privateAccessToken,
+      mirrorRepo.data.owner.login,
+      mirrorRepo.data.name,
+    )
+
+    // Create a temporary directory to clone the repo into
+    const tempDir = temporaryDirectory()
+
+    const options: Partial<SimpleGitOptions> = {
+      config: [
+        `user.name=pma[bot]`,
+        // We want to use the private installation ID as the email so that we can push to the private repo
+        `user.email=${privateInstallationId}+pma[bot]@users.noreply.github.com`,
+      ],
+    }
+    const git = simpleGit(tempDir, options)
+
+    // Create a clone of the fork that contains only what is necessary to push to the mirror
+    const cloneConfig = ['--single-branch', '--branch', branch, '--no-tags']
+    await git.clone(forkRemote, tempDir, cloneConfig)
+
+    // Push the commits from cloned source up to the newly created mirror
+    await git.addRemote('mirror', mirrorRemote)
+    await git.push(['--no-verify', 'mirror', branch])
 
     reposApiLogger.info('Mirror created', {
-      org: newRepo.data.owner.login,
-      name: newRepo.data.name,
+      org: mirrorRepo.data.owner.login,
+      name: mirrorRepo.data.name,
     })
 
     return {
       success: true,
-      data: newRepo.data,
+      data: mirrorRepo.data,
     }
   } catch (error) {
     reposApiLogger.error('Error creating mirror', { error })
@@ -171,17 +252,15 @@ export const createMirrorHandler = async ({
       (error as Error)?.message ??
       'An error occurred'
 
-    if (privateOctokit && newRepo) {
-      try {
-        // Clean up the private mirror repo made
-        await privateOctokit.rest.repos.delete({
-          owner: newRepo.data.owner.login,
-          repo: input.newRepoName,
-        })
-      } catch (deleteError) {
-        reposApiLogger.error('Failed to delete mirror', { deleteError })
-      }
-    }
+    await deleteMirrorAndSyncBranch({
+      privateOctokit,
+      mirrorRepoRef: mirrorRepo && {
+        owner: mirrorRepo.data.owner.login,
+        name: input.newRepoName,
+      },
+      publicOctokit,
+      syncBranchRef,
+    })
 
     throw new TRPCError({
       code: 'INTERNAL_SERVER_ERROR',
@@ -239,7 +318,9 @@ export const listMirrorsHandler = async ({
   }
 }
 
-// Edits the name of a mirror
+// Edits the name of a mirror and renames the sync destination branch on
+// the public fork (which shares the mirror's name) so that the two
+// stay aligned.
 export const editMirrorHandler = async ({
   input,
 }: {
@@ -250,17 +331,43 @@ export const editMirrorHandler = async ({
 
     const config = await getConfig(input.orgId)
 
-    const installationId = await appOctokit().rest.apps.getOrgInstallation({
-      org: config.privateOrg,
-    })
+    const octokitData = await getAuthenticatedOctokit(
+      config.publicOrg,
+      config.privateOrg,
+    )
+    const publicOctokit = octokitData.contribution.octokit
+    const privateOctokit = octokitData.private.octokit
 
-    const octokit = installationOctokit(String(installationId.data.id))
+    // Lookup the mirror's associated fork to rename the sync branch later
+    const forkRepoRef = await getForkRepoFromMirror(
+      privateOctokit,
+      config.privateOrg,
+      input.mirrorName,
+    )
 
-    const repo = await octokit.rest.repos.update({
+    const repo = await privateOctokit.rest.repos.update({
       owner: config.privateOrg,
       repo: input.mirrorName,
       name: input.newMirrorName,
     })
+
+    if (forkRepoRef) {
+      try {
+        await publicOctokit.rest.repos.renameBranch({
+          owner: forkRepoRef.owner,
+          repo: forkRepoRef.name,
+          branch: input.mirrorName,
+          new_name: input.newMirrorName,
+        })
+      } catch (error) {
+        reposApiLogger.error('Failed to rename sync branch on fork', {
+          error,
+          forkRepoRef,
+          oldBranch: input.mirrorName,
+          newBranch: input.newMirrorName,
+        })
+      }
+    }
 
     return {
       success: true,
@@ -282,7 +389,7 @@ export const editMirrorHandler = async ({
   }
 }
 
-// Deletes a mirror
+// Deletes a mirror and its sync-destination branch on the public fork.
 export const deleteMirrorHandler = async ({
   input,
 }: {
@@ -293,15 +400,28 @@ export const deleteMirrorHandler = async ({
 
     const config = await getConfig(input.orgId)
 
-    const installationId = await appOctokit().rest.apps.getOrgInstallation({
-      org: config.privateOrg,
-    })
+    const octokitData = await getAuthenticatedOctokit(
+      config.publicOrg,
+      config.privateOrg,
+    )
+    const publicOctokit = octokitData.contribution.octokit
+    const privateOctokit = octokitData.private.octokit
 
-    const octokit = installationOctokit(String(installationId.data.id))
+    const forkRepoRef = await getForkRepoFromMirror(
+      privateOctokit,
+      config.privateOrg,
+      input.mirrorName,
+    )
 
-    await octokit.rest.repos.delete({
-      owner: config.privateOrg,
-      repo: input.mirrorName,
+    await deleteMirrorAndSyncBranch({
+      privateOctokit,
+      mirrorRepoRef: { owner: config.privateOrg, name: input.mirrorName },
+      publicOctokit,
+      syncBranchRef: forkRepoRef && {
+        owner: forkRepoRef.owner,
+        repo: forkRepoRef.name,
+        branch: input.mirrorName,
+      },
     })
 
     return {

--- a/src/server/repos/controller.ts
+++ b/src/server/repos/controller.ts
@@ -239,7 +239,9 @@ export const createMirrorHandler = async ({
       // Push commits in chunks so that large pushes don't encounter timeout issues
       const chunkSize = Number(process.env.MIRROR_PUSH_CHUNK_SIZE ?? 1000)
       const commitCount = Number(
-        (await git.raw(['rev-list', '--count', branch])).trim(),
+        (
+          await git.raw(['rev-list', '--first-parent', '--count', branch])
+        ).trim(),
       )
 
       for (let chunk = 1; chunk * chunkSize < commitCount; chunk++) {
@@ -247,6 +249,7 @@ export const createMirrorHandler = async ({
         const sha = (
           await git.raw([
             'rev-list',
+            '--first-parent',
             `--skip=${commitCount - chunk * chunkSize}`,
             '--max-count=1',
             branch,

--- a/src/server/repos/controller.ts
+++ b/src/server/repos/controller.ts
@@ -243,12 +243,11 @@ export const createMirrorHandler = async ({
       )
 
       for (let chunk = 1; chunk * chunkSize < commitCount; chunk++) {
-        // Get the sha for the end of the next chunk of commits to push
+        // Get the sha for the end of the next chunk of commits to push by skipping the recent commits
         const sha = (
           await git.raw([
             'rev-list',
-            '--reverse',
-            `--skip=${chunk * chunkSize - 1}`,
+            `--skip=${commitCount - chunk * chunkSize}`,
             '--max-count=1',
             branch,
           ])

--- a/src/server/repos/controller.ts
+++ b/src/server/repos/controller.ts
@@ -150,8 +150,8 @@ export const createMirrorHandler = async ({
     await git.push(['--no-verify', 'upstream', defaultBranch])
 
     // Create a new branch on both
-    await git.checkoutBranch(input.newBranchName, defaultBranch)
-    await git.push(['--no-verify', 'origin', input.newBranchName])
+    await git.checkoutBranch(input.newRepoName, defaultBranch)
+    await git.push(['--no-verify', 'origin', input.newRepoName])
 
     reposApiLogger.info('Mirror created', {
       org: newRepo.data.owner.login,

--- a/src/server/repos/schema.ts
+++ b/src/server/repos/schema.ts
@@ -21,7 +21,6 @@ export const CreateMirrorSchema = z.object({
   forkRepoName: z.string(),
   forkId: z.string(),
   newRepoName: mirrorNameSchema,
-  newBranchName: z.string(),
 })
 
 export const ListMirrorsSchema = z.object({

--- a/test/app.test.ts
+++ b/test/app.test.ts
@@ -1,4 +1,4 @@
-import { describe, beforeEach, it, expect } from 'vitest'
+import { describe, beforeEach, it, expect, vi } from 'vitest'
 import nock from 'nock'
 
 // Requiring our app implementation
@@ -34,6 +34,7 @@ describe('Webhooks events', () => {
   beforeEach(() => {
     nock.disableNetConnect()
     om.resetMocks()
+    vi.stubEnv('SKIP_BRANCH_PROTECTION_CREATION', '')
     probot = new Probot({
       appId: 12345,
       privateKey,

--- a/test/octomock/index.ts
+++ b/test/octomock/index.ts
@@ -201,6 +201,7 @@ const mockFunctions = {
       listForUser: vi.fn(),
       getCommitRefSha: vi.fn(),
       getCustomPropertiesValues: vi.fn(),
+      renameBranch: vi.fn(),
     },
     issues: {
       list: vi.fn(),
@@ -301,6 +302,11 @@ const mockFunctions = {
     },
     users: {
       getAuthenticated: vi.fn(),
+    },
+    git: {
+      getRef: vi.fn(),
+      createRef: vi.fn(),
+      deleteRef: vi.fn(),
     },
   },
 }

--- a/test/server/repos.test.ts
+++ b/test/server/repos.test.ts
@@ -408,13 +408,16 @@ describe('Repos router', () => {
     )
     om.mockFunctions.rest.repos.createInOrg.mockResolvedValue(fakeMirrorRepo)
 
-    // 5 commits with chunk size 2: loop iterates at skip=1 (idx 1) and skip=3
-    // (idx 3), then a final tip push lands the actual branch — three pushes.
+    // 5 commits with chunk size 2: loop iterates at skip=3 (c2) and skip=1
+    // (c4), then a final tip push lands the actual branch — three pushes.
+    // rev-list returns commits newest-first, so --skip=N from a 5-commit
+    // history returns the commit at oldest-first index (4 - N).
     const commits = ['c1', 'c2', 'c3', 'c4', 'c5']
     stubbedGit.raw.mockImplementation(async (args: string[]) => {
       if (args.includes('--count')) return `${commits.length}\n`
       const skipArg = args.find((a) => a.startsWith('--skip='))!
-      return `${commits[Number(skipArg.split('=')[1])]}\n`
+      const skip = Number(skipArg.split('=')[1])
+      return `${commits[commits.length - 1 - skip]}\n`
     })
     vi.stubEnv('MIRROR_PUSH_CHUNK_SIZE', '2')
 

--- a/test/server/repos.test.ts
+++ b/test/server/repos.test.ts
@@ -8,6 +8,7 @@ const stubbedGit = {
   fetch: vi.fn(),
   checkoutBranch: vi.fn(),
   mergeFromTo: vi.fn(),
+  raw: vi.fn(),
 }
 
 vi.mock('simple-git', () => ({
@@ -117,6 +118,9 @@ describe('Repos router', () => {
     om.resetMocks()
     vi.resetAllMocks()
     process.env = { ...UNMODIFIED_ENV }
+    // Default to a small commit count so the chunked push loop is skipped and
+    // only the final tip push runs. Tests that exercise chunking override this.
+    stubbedGit.raw.mockResolvedValue('2\n')
   })
 
   it('should create a mirror when repo does not exist', async () => {
@@ -375,6 +379,69 @@ describe('Repos router', () => {
     expect(stubbedGit.addRemote).toHaveBeenCalledTimes(1)
     expect(stubbedGit.push).toHaveBeenCalledTimes(1)
     expect(stubbedGit.checkoutBranch).not.toHaveBeenCalled()
+
+    expect(res).toEqual({
+      success: true,
+      pending: false,
+      data: fakeMirrorRepo.data,
+    })
+  })
+
+  it('pushes large repos in chunks of commits', async () => {
+    const caller = t.createCallerFactory(reposRouter)(createTestContext())
+
+    vi.spyOn(config, 'getConfig').mockResolvedValue({
+      publicOrg: 'github',
+      privateOrg: 'github-test',
+    })
+
+    om.mockFunctions.rest.apps.getOrgInstallation.mockResolvedValue(
+      fakeOrgInstallation,
+    )
+    om.mockFunctions.rest.orgs.get.mockResolvedValue(fakeOrg)
+    om.mockFunctions.rest.repos.get.mockResolvedValueOnce(repoNotFound)
+    om.mockFunctions.rest.repos.get.mockResolvedValueOnce(fakeForkRepo)
+    om.mockFunctions.rest.git.getRef.mockResolvedValue(fakeBranchRef)
+    om.mockFunctions.rest.git.createRef.mockResolvedValue({ status: 201 })
+    om.mockFunctions.rest.orgs.getAllCustomProperties.mockResolvedValue(
+      fakeOrgCustomProperties,
+    )
+    om.mockFunctions.rest.repos.createInOrg.mockResolvedValue(fakeMirrorRepo)
+
+    // 5 commits with chunk size 2: loop iterates at skip=1 (idx 1) and skip=3
+    // (idx 3), then a final tip push lands the actual branch — three pushes.
+    const commits = ['c1', 'c2', 'c3', 'c4', 'c5']
+    stubbedGit.raw.mockImplementation(async (args: string[]) => {
+      if (args.includes('--count')) return `${commits.length}\n`
+      const skipArg = args.find((a) => a.startsWith('--skip='))!
+      return `${commits[Number(skipArg.split('=')[1])]}\n`
+    })
+    vi.stubEnv('MIRROR_PUSH_CHUNK_SIZE', '2')
+
+    const res = await caller.createMirror({
+      forkId: 'test',
+      orgId: 'test',
+      forkRepoName: 'fork-test',
+      forkRepoOwner: 'github',
+      newRepoName: 'test',
+    })
+
+    expect(stubbedGit.push).toHaveBeenCalledTimes(3)
+    expect(stubbedGit.push).toHaveBeenNthCalledWith(1, [
+      '--no-verify',
+      'mirror',
+      'c2:refs/heads/main',
+    ])
+    expect(stubbedGit.push).toHaveBeenNthCalledWith(2, [
+      '--no-verify',
+      'mirror',
+      'c4:refs/heads/main',
+    ])
+    expect(stubbedGit.push).toHaveBeenNthCalledWith(3, [
+      '--no-verify',
+      'mirror',
+      'main',
+    ])
 
     expect(res).toEqual({
       success: true,

--- a/test/server/repos.test.ts
+++ b/test/server/repos.test.ts
@@ -180,6 +180,7 @@ describe('Repos router', () => {
 
     expect(res).toEqual({
       success: true,
+      pending: false,
       data: fakeMirrorRepo.data,
     })
   })
@@ -377,7 +378,81 @@ describe('Repos router', () => {
 
     expect(res).toEqual({
       success: true,
+      pending: false,
       data: fakeMirrorRepo.data,
+    })
+  })
+
+  it('returns pending when git work exceeds the sync timeout and cleans up on background failure', async () => {
+    const caller = t.createCallerFactory(reposRouter)(createTestContext())
+
+    vi.spyOn(config, 'getConfig').mockResolvedValue({
+      publicOrg: 'github',
+      privateOrg: 'github-test',
+    })
+
+    om.mockFunctions.rest.apps.getOrgInstallation.mockResolvedValue(
+      fakeOrgInstallation,
+    )
+    om.mockFunctions.rest.orgs.get.mockResolvedValue(fakeOrg)
+    om.mockFunctions.rest.repos.get.mockResolvedValueOnce(repoNotFound)
+    om.mockFunctions.rest.repos.get.mockResolvedValueOnce(fakeForkRepo)
+    om.mockFunctions.rest.git.getRef.mockResolvedValue(fakeBranchRef)
+    om.mockFunctions.rest.git.createRef.mockResolvedValue({ status: 201 })
+    om.mockFunctions.rest.orgs.getAllCustomProperties.mockResolvedValue(
+      fakeOrgCustomProperties,
+    )
+    om.mockFunctions.rest.repos.createInOrg.mockResolvedValue(fakeMirrorRepo)
+
+    // Force the git work to never resolve during the sync window so the
+    // timeout branch is taken. Capture the reject so we can trip it after.
+    let rejectPush: (err: Error) => void = () => {}
+    const pushPromise = new Promise((_resolve, reject) => {
+      rejectPush = reject
+    })
+    stubbedGit.clone.mockResolvedValue({})
+    stubbedGit.addRemote.mockResolvedValue({})
+    stubbedGit.push.mockReturnValue(pushPromise)
+
+    // Resolve when cleanup actually runs, so the test waits exactly until the
+    // background .catch handler completes
+    const cleanupCalled = new Promise<void>((resolve) => {
+      om.mockFunctions.rest.git.deleteRef.mockImplementation(async () => {
+        resolve()
+        return {}
+      })
+    })
+    om.mockFunctions.rest.repos.delete.mockResolvedValue({})
+
+    // Shrink the sync timeout so the test completes quickly without fake timers.
+    vi.stubEnv('MIRROR_SYNC_TIMEOUT_MS', '50')
+
+    const res = await caller.createMirror({
+      forkId: 'test',
+      orgId: 'test',
+      forkRepoName: 'fork-test',
+      forkRepoOwner: 'github',
+      newRepoName: 'test',
+    })
+
+    expect(res).toEqual({
+      success: true,
+      pending: true,
+      data: fakeMirrorRepo.data,
+    })
+
+    // Trip the background failure and wait for cleanup to actually run.
+    rejectPush(new Error('background push failed'))
+    await cleanupCalled
+
+    expect(om.mockFunctions.rest.repos.delete).toHaveBeenCalledWith({
+      owner: 'github-test',
+      repo: 'test',
+    })
+    expect(om.mockFunctions.rest.git.deleteRef).toHaveBeenCalledWith({
+      owner: 'github',
+      repo: 'fork-test',
+      ref: 'heads/test',
     })
   })
 

--- a/test/server/repos.test.ts
+++ b/test/server/repos.test.ts
@@ -118,6 +118,7 @@ describe('Repos router', () => {
     om.resetMocks()
     vi.resetAllMocks()
     process.env = { ...UNMODIFIED_ENV }
+    vi.stubEnv('SKIP_BRANCH_PROTECTION_CREATION', '')
     // Default to a small commit count so the chunked push loop is skipped and
     // only the final tip push runs. Tests that exercise chunking override this.
     stubbedGit.raw.mockResolvedValue('2\n')

--- a/test/server/repos.test.ts
+++ b/test/server/repos.test.ts
@@ -48,6 +48,7 @@ const fakeForkRepo = {
   data: {
     clone_url: 'https://github.com/github-test/fork-test.git',
     login: 'fork-test',
+    default_branch: 'main',
     owner: {
       login: 'github-test',
     },
@@ -88,6 +89,15 @@ const repoNotFound = {
   },
 }
 
+const fakeBranchRef = {
+  status: 200,
+  data: {
+    object: {
+      sha: 'deadbeef',
+    },
+  },
+}
+
 const fakeOrgCustomProperties = {
   status: 200,
   data: [
@@ -123,6 +133,8 @@ describe('Repos router', () => {
     om.mockFunctions.rest.orgs.get.mockResolvedValue(fakeOrg)
     om.mockFunctions.rest.repos.get.mockResolvedValueOnce(repoNotFound)
     om.mockFunctions.rest.repos.get.mockResolvedValueOnce(fakeForkRepo)
+    om.mockFunctions.rest.git.getRef.mockResolvedValue(fakeBranchRef)
+    om.mockFunctions.rest.git.createRef.mockResolvedValue({ status: 201 })
     om.mockFunctions.rest.orgs.getAllCustomProperties.mockResolvedValue(
       fakeOrgCustomProperties,
     )
@@ -142,10 +154,29 @@ describe('Repos router', () => {
     // TODO: use real git operations and verify fs state after
     expect(configSpy).toHaveBeenCalledTimes(1)
     expect(om.mockFunctions.rest.repos.get).toHaveBeenCalledTimes(2)
+    expect(om.mockFunctions.rest.git.getRef).toHaveBeenCalledTimes(1)
+    expect(om.mockFunctions.rest.git.createRef).toHaveBeenCalledWith(
+      expect.objectContaining({
+        ref: 'refs/heads/test',
+        sha: 'deadbeef',
+      }),
+    )
     expect(stubbedGit.clone).toHaveBeenCalledTimes(1)
-    expect(stubbedGit.addRemote).toHaveBeenCalledTimes(1)
-    expect(stubbedGit.push).toHaveBeenCalledTimes(2)
-    expect(stubbedGit.checkoutBranch).toHaveBeenCalledTimes(1)
+    const cloneArgs = stubbedGit.clone.mock.calls[0]
+    expect(cloneArgs[2]).toEqual([
+      '--single-branch',
+      '--branch',
+      'main',
+      '--no-tags',
+    ])
+    expect(stubbedGit.addRemote.mock.calls[0][0]).toBe('mirror')
+    expect(stubbedGit.push).toHaveBeenCalledTimes(1)
+    expect(stubbedGit.push).toHaveBeenCalledWith([
+      '--no-verify',
+      'mirror',
+      'main',
+    ])
+    expect(stubbedGit.checkoutBranch).not.toHaveBeenCalled()
 
     expect(res).toEqual({
       success: true,
@@ -168,17 +199,15 @@ describe('Repos router', () => {
     om.mockFunctions.rest.repos.get.mockResolvedValue(fakeMirrorRepo)
     om.mockFunctions.rest.repos.delete.mockResolvedValue({})
 
-    await caller
-      .createMirror({
+    await expect(
+      caller.createMirror({
         forkId: 'test',
         orgId: 'test',
         forkRepoName: 'fork-test',
         forkRepoOwner: 'github',
         newRepoName: 'test',
-      })
-      .catch((error) => {
-        expect(error.message).toEqual('Repo github-test/test already exists')
-      })
+      }),
+    ).rejects.toThrow('a mirror named test already exists in github')
 
     expect(configSpy).toHaveBeenCalledTimes(1)
     expect(om.mockFunctions.rest.repos.get).toHaveBeenCalledTimes(1)
@@ -199,13 +228,15 @@ describe('Repos router', () => {
     )
     om.mockFunctions.rest.orgs.get.mockResolvedValue(fakeOrg)
     om.mockFunctions.rest.repos.get.mockResolvedValueOnce(repoNotFound)
-    om.mockFunctions.rest.repos.get.mockResolvedValueOnce(fakeMirrorRepo)
+    om.mockFunctions.rest.repos.get.mockResolvedValueOnce(fakeForkRepo)
+    om.mockFunctions.rest.git.getRef.mockResolvedValue(fakeBranchRef)
+    om.mockFunctions.rest.git.createRef.mockResolvedValue({ status: 201 })
     stubbedGit.clone.mockResolvedValue({})
     om.mockFunctions.rest.orgs.getAllCustomProperties.mockResolvedValue({
       data: [{ fork: 'test' }],
     })
     om.mockFunctions.rest.repos.createInOrg.mockResolvedValue({
-      data: { owner: { login: 'github' } },
+      data: { owner: { login: 'github' }, name: 'test' },
     })
 
     // error after repo creation so that cleanup can be tested
@@ -231,6 +262,11 @@ describe('Repos router', () => {
       owner: 'github',
       repo: 'test',
     })
+    expect(om.mockFunctions.rest.git.deleteRef).toHaveBeenCalledWith({
+      owner: 'github',
+      repo: 'fork-test',
+      ref: 'heads/test',
+    })
     expect(stubbedGit.clone).toHaveBeenCalledTimes(1)
   })
 
@@ -247,13 +283,15 @@ describe('Repos router', () => {
     )
     om.mockFunctions.rest.orgs.get.mockResolvedValue(fakeOrg)
     om.mockFunctions.rest.repos.get.mockResolvedValueOnce(repoNotFound)
-    om.mockFunctions.rest.repos.get.mockResolvedValueOnce(fakeMirrorRepo)
+    om.mockFunctions.rest.repos.get.mockResolvedValueOnce(fakeForkRepo)
+    om.mockFunctions.rest.git.getRef.mockResolvedValue(fakeBranchRef)
+    om.mockFunctions.rest.git.createRef.mockResolvedValue({ status: 201 })
     stubbedGit.clone.mockResolvedValue({})
     om.mockFunctions.rest.orgs.getAllCustomProperties.mockResolvedValue({
       data: [{ fork: 'test' }],
     })
     om.mockFunctions.rest.repos.createInOrg.mockResolvedValue({
-      data: { owner: { login: 'github-test' } },
+      data: { owner: { login: 'github-test' }, name: 'test' },
     })
     om.mockFunctions.rest.repos.delete.mockResolvedValue({})
 
@@ -280,6 +318,11 @@ describe('Repos router', () => {
       owner: 'github-test',
       repo: 'test',
     })
+    expect(om.mockFunctions.rest.git.deleteRef).toHaveBeenCalledWith({
+      owner: 'github',
+      repo: 'fork-test',
+      ref: 'heads/test',
+    })
     expect(stubbedGit.clone).toHaveBeenCalledTimes(1)
   })
 
@@ -297,6 +340,8 @@ describe('Repos router', () => {
     om.mockFunctions.rest.orgs.get.mockResolvedValue(fakeOrg)
     om.mockFunctions.rest.repos.get.mockResolvedValueOnce(repoNotFound)
     om.mockFunctions.rest.repos.get.mockResolvedValueOnce(fakeForkRepo)
+    om.mockFunctions.rest.git.getRef.mockResolvedValue(fakeBranchRef)
+    om.mockFunctions.rest.git.createRef.mockResolvedValue({ status: 201 })
     om.mockFunctions.rest.orgs.getAllCustomProperties.mockResolvedValue(
       fakeOrgCustomProperties,
     )
@@ -327,8 +372,8 @@ describe('Repos router', () => {
       }),
     )
     expect(stubbedGit.addRemote).toHaveBeenCalledTimes(1)
-    expect(stubbedGit.push).toHaveBeenCalledTimes(2)
-    expect(stubbedGit.checkoutBranch).toHaveBeenCalledTimes(1)
+    expect(stubbedGit.push).toHaveBeenCalledTimes(1)
+    expect(stubbedGit.checkoutBranch).not.toHaveBeenCalled()
 
     expect(res).toEqual({
       success: true,
@@ -352,5 +397,154 @@ describe('Repos router', () => {
           /Mirror name cannot exceed 100 characters/,
         )
       })
+  })
+
+  describe('editMirror', () => {
+    it('renames the mirror and the sync branch ref on the public fork', async () => {
+      const caller = t.createCallerFactory(reposRouter)(createTestContext())
+
+      vi.spyOn(config, 'getConfig').mockResolvedValue({
+        publicOrg: 'github',
+        privateOrg: 'github-test',
+      })
+
+      om.mockFunctions.rest.apps.getOrgInstallation.mockResolvedValue(
+        fakeOrgInstallation,
+      )
+      om.mockFunctions.rest.repos.getCustomPropertiesValues.mockResolvedValue({
+        status: 200,
+        data: [{ property_name: 'fork', value: 'github/fork-test' }],
+      })
+      om.mockFunctions.rest.repos.update.mockResolvedValue({
+        status: 200,
+        data: { name: 'renamed' },
+      })
+      om.mockFunctions.rest.repos.renameBranch.mockResolvedValue({
+        status: 201,
+      })
+
+      const res = await caller.editMirror({
+        orgId: 'test',
+        mirrorName: 'old-name',
+        newMirrorName: 'new-name',
+      })
+
+      expect(om.mockFunctions.rest.repos.update).toHaveBeenCalledWith({
+        owner: 'github-test',
+        repo: 'old-name',
+        name: 'new-name',
+      })
+      expect(om.mockFunctions.rest.repos.renameBranch).toHaveBeenCalledWith({
+        owner: 'github',
+        repo: 'fork-test',
+        branch: 'old-name',
+        new_name: 'new-name',
+      })
+      expect(res.success).toBe(true)
+    })
+
+    it('still succeeds when the fork ref rename fails', async () => {
+      const caller = t.createCallerFactory(reposRouter)(createTestContext())
+
+      vi.spyOn(config, 'getConfig').mockResolvedValue({
+        publicOrg: 'github',
+        privateOrg: 'github-test',
+      })
+
+      om.mockFunctions.rest.apps.getOrgInstallation.mockResolvedValue(
+        fakeOrgInstallation,
+      )
+      om.mockFunctions.rest.repos.getCustomPropertiesValues.mockResolvedValue({
+        status: 200,
+        data: [{ property_name: 'fork', value: 'github/fork-test' }],
+      })
+      om.mockFunctions.rest.repos.update.mockResolvedValue({
+        status: 200,
+        data: { name: 'renamed' },
+      })
+      om.mockFunctions.rest.repos.renameBranch.mockRejectedValue(
+        new Error('no branch'),
+      )
+
+      const res = await caller.editMirror({
+        orgId: 'test',
+        mirrorName: 'old-name',
+        newMirrorName: 'new-name',
+      })
+
+      expect(om.mockFunctions.rest.repos.update).toHaveBeenCalled()
+      expect(res.success).toBe(true)
+    })
+
+    it('skips the branch rename when the fork custom property cannot be read', async () => {
+      const caller = t.createCallerFactory(reposRouter)(createTestContext())
+
+      vi.spyOn(config, 'getConfig').mockResolvedValue({
+        publicOrg: 'github',
+        privateOrg: 'github-test',
+      })
+
+      om.mockFunctions.rest.apps.getOrgInstallation.mockResolvedValue(
+        fakeOrgInstallation,
+      )
+      om.mockFunctions.rest.repos.getCustomPropertiesValues.mockRejectedValue(
+        new Error('nope'),
+      )
+      om.mockFunctions.rest.repos.update.mockResolvedValue({
+        status: 200,
+        data: { name: 'renamed' },
+      })
+
+      const res = await caller.editMirror({
+        orgId: 'test',
+        mirrorName: 'old-name',
+        newMirrorName: 'new-name',
+      })
+
+      expect(om.mockFunctions.rest.repos.update).toHaveBeenCalledWith({
+        owner: 'github-test',
+        repo: 'old-name',
+        name: 'new-name',
+      })
+      expect(om.mockFunctions.rest.repos.renameBranch).not.toHaveBeenCalled()
+      expect(res.success).toBe(true)
+    })
+  })
+
+  describe('deleteMirror', () => {
+    it('deletes the mirror and the sync branch ref on the public fork', async () => {
+      const caller = t.createCallerFactory(reposRouter)(createTestContext())
+
+      vi.spyOn(config, 'getConfig').mockResolvedValue({
+        publicOrg: 'github',
+        privateOrg: 'github-test',
+      })
+
+      om.mockFunctions.rest.apps.getOrgInstallation.mockResolvedValue(
+        fakeOrgInstallation,
+      )
+      om.mockFunctions.rest.repos.getCustomPropertiesValues.mockResolvedValue({
+        status: 200,
+        data: [{ property_name: 'fork', value: 'github/fork-test' }],
+      })
+      om.mockFunctions.rest.repos.delete.mockResolvedValue({ status: 204 })
+      om.mockFunctions.rest.git.deleteRef.mockResolvedValue({ status: 204 })
+
+      const res = await caller.deleteMirror({
+        orgId: 'test',
+        mirrorName: 'to-delete',
+      })
+
+      expect(om.mockFunctions.rest.repos.delete).toHaveBeenCalledWith({
+        owner: 'github-test',
+        repo: 'to-delete',
+      })
+      expect(om.mockFunctions.rest.git.deleteRef).toHaveBeenCalledWith({
+        owner: 'github',
+        repo: 'fork-test',
+        ref: 'heads/to-delete',
+      })
+      expect(res.success).toBe(true)
+    })
   })
 })

--- a/test/server/repos.test.ts
+++ b/test/server/repos.test.ts
@@ -136,7 +136,6 @@ describe('Repos router', () => {
       orgId: 'test',
       forkRepoName: 'fork-test',
       forkRepoOwner: 'github',
-      newBranchName: 'test',
       newRepoName: 'test',
     })
 
@@ -175,7 +174,6 @@ describe('Repos router', () => {
         orgId: 'test',
         forkRepoName: 'fork-test',
         forkRepoOwner: 'github',
-        newBranchName: 'test',
         newRepoName: 'test',
       })
       .catch((error) => {
@@ -221,7 +219,6 @@ describe('Repos router', () => {
         orgId: 'test',
         forkRepoName: 'fork-test',
         forkRepoOwner: 'github',
-        newBranchName: 'test',
         newRepoName: 'test',
       })
       .catch((error) => {
@@ -271,7 +268,6 @@ describe('Repos router', () => {
         orgId: 'test',
         forkRepoName: 'fork-test',
         forkRepoOwner: 'github',
-        newBranchName: 'test',
         newRepoName: 'test',
       })
       .catch((error) => {
@@ -317,7 +313,6 @@ describe('Repos router', () => {
       orgId: 'test',
       forkRepoName: 'fork-test',
       forkRepoOwner: 'github',
-      newBranchName: 'test',
       newRepoName: 'test',
     })
 
@@ -350,7 +345,6 @@ describe('Repos router', () => {
         orgId: 'test',
         forkRepoName: 'fork-test',
         forkRepoOwner: 'github',
-        newBranchName: 'test',
         newRepoName: 'a'.repeat(101),
       })
       .catch((error) => {

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -20,10 +20,10 @@ export default defineConfig({
         'build/**',
       ],
       thresholds: {
-        lines: 45,
-        functions: 35,
-        branches: 35,
-        statements: 45,
+        statements: 50,
+        branches: 40,
+        functions: 45,
+        lines: 50,
       },
     },
     typecheck: {


### PR DESCRIPTION
# Pull Request

<!--
PR title needs to be prefixed with a conventional commit type
(build,chore,ci,docs,feat,fix,perf,refactor,revert,style,test)

It should also be brief and descriptive for a good changelog entry

examples: "feat: add new logger" or "fix: remove unused imports"
-->

## Proposed Changes

<!-- Describe what the changes are and link to a GitHub Issue if one exists -->

This change resolves cloning and pushing failures when mirroring large repositories. There are three major components of the change:                             
                                         
  1. Background long-running mirror creation. Slow git clones and pushes are decoupled from the request lifecycle. If the work exceeds MIRROR_SYNC_TIMEOUT_MS (default 30s), the request returns `pending: true` and the work continues in the background, with cleanup on failure. The UI shows a "creation continuing in background" flash on pending responses.
  2. Chunked pushes. Pushes are split into batches of MIRROR_PUSH_CHUNK_SIZE commits (default 1000) so a single large push doesn't time out. The branch tip is pushed last after all chunks land.
  3. Synchronized fork sync-branch lifecycle. The public-fork sync branch is created when the mirror is created, renamed when the mirror is renamed, and deleted when the mirror is deleted (including when background creation fails). This also includes dropping the redundant newBranchName input since the sync branch always shares the mirror's name.

This change required many fixes to get the incredibly tricky git logic right since `git rev-list --reverse --max-count=1` does not behave intuitively and the presence of merge commits creates a non-linear commit history which caused chunked pushed to break in some cases.

I think it makes sense to release this change in its current state to fix the current issue but further work should be done to improve the UX around backgrounded mirror creation. Currently, the pending flash doesn't go away until the user dismisses it or refreshes, and there is no notice provided when a backgrounded mirror creation completes. Due to the chunked pushes, the repo is populated from old to new and users could potentially clone down an incomplete mirror. The in-progress mirror also appears in the mirror list and has options to rename or delete it which could break things.

## Readiness Checklist

### Author/Contributor

- [x] If documentation is needed for this change, has that been included in this pull request
- [x] run `npm run format` and fix any formatting issues that have been introduced
- [x] run `npm run lint` and fix any linting issues that have been introduced
- [x] run `npm run test` and run tests