### PR TITLE
fix: temporary directories not being cleaned up after use

### DIFF
--- a/src/server/git/controller.ts
+++ b/src/server/git/controller.ts
@@ -2,6 +2,7 @@ import simpleGit, { SimpleGitOptions } from 'simple-git'
 import { generateAuthUrl } from '../../utils/auth'
 import { temporaryDirectory } from 'tempy'
 import { logger } from '../../utils/logger'
+import { cleanupTempDir } from '../../utils/temp-dir'
 import { SyncReposSchema } from './schema'
 
 const gitApiLogger = logger.getSubLogger({ name: 'git-api' })
@@ -12,6 +13,7 @@ export const syncReposHandler = async ({
 }: {
   input: SyncReposSchema // owner, name, branch, accessToken
 }) => {
+  let tempDir: string | undefined
   try {
     gitApiLogger.info(
       'Syncing source repo: ',
@@ -53,7 +55,7 @@ export const syncReposHandler = async ({
     )
 
     // First clone the source and destination repos into the same folder
-    const tempDir = temporaryDirectory()
+    tempDir = temporaryDirectory()
 
     const options: Partial<SimpleGitOptions> = {
       config: [
@@ -164,5 +166,7 @@ export const syncReposHandler = async ({
     return {
       success: false,
     }
+  } finally {
+    await cleanupTempDir(tempDir, gitApiLogger)
   }
 }

--- a/src/server/repos/controller.ts
+++ b/src/server/repos/controller.ts
@@ -11,6 +11,7 @@ import {
 } from '../../bot/octokit'
 import { Octokit } from '../../bot/rest'
 import { logger } from '../../utils/logger'
+import { cleanupTempDir } from '../../utils/temp-dir'
 import {
   CreateMirrorSchema,
   DeleteMirrorSchema,
@@ -97,6 +98,7 @@ export const createMirrorHandler = async ({
   let publicOctokit: Octokit | undefined
   let mirrorRepo: MirrorRepo | undefined
   let syncBranchRef: SyncBranchRef | undefined
+  let tempDir: string | undefined
 
   try {
     reposApiLogger.info('createMirror', { input: input })
@@ -215,7 +217,7 @@ export const createMirrorHandler = async ({
     )
 
     // Create a temporary directory to clone the repo into
-    const tempDir = temporaryDirectory()
+    tempDir = temporaryDirectory()
 
     const options: Partial<SimpleGitOptions> = {
       config: [
@@ -313,6 +315,7 @@ export const createMirrorHandler = async ({
             syncBranchRef,
           })
         })
+        .finally(() => cleanupTempDir(tempDir, reposApiLogger))
 
       return {
         success: true,
@@ -322,6 +325,8 @@ export const createMirrorHandler = async ({
     }
 
     clearTimeout(timer)
+
+    await cleanupTempDir(tempDir, reposApiLogger)
 
     reposApiLogger.info('Mirror created', {
       org: mirrorRepo.data.owner.login,
@@ -341,6 +346,8 @@ export const createMirrorHandler = async ({
       (error as any)?.response?.data?.message ??
       (error as Error)?.message ??
       'An error occurred'
+
+    await cleanupTempDir(tempDir, reposApiLogger)
 
     await deleteMirrorAndSyncBranch({
       privateOctokit,

--- a/src/utils/temp-dir.ts
+++ b/src/utils/temp-dir.ts
@@ -1,0 +1,19 @@
+import { rm } from 'node:fs/promises'
+import type { Logger } from 'tslog'
+
+// Removes a temp directory created by tempy. Logs (but does not throw on)
+// cleanup failures so callers can use this from finally blocks safely.
+export const cleanupTempDir = async (
+  tempDir: string | undefined,
+  log: Logger<unknown>,
+) => {
+  if (!tempDir) return
+  try {
+    await rm(tempDir, { recursive: true, force: true })
+  } catch (cleanupError) {
+    log.warn('Failed to clean up temp directory', {
+      tempDir,
+      error: cleanupError,
+    })
+  }
+}

--- a/test/server/git/controller.test.ts
+++ b/test/server/git/controller.test.ts
@@ -2,6 +2,7 @@ import { vi, describe, beforeEach, it, expect } from 'vitest'
 import { syncReposHandler } from '../../../src/server/git/controller'
 import * as auth from '../../../src/utils/auth'
 import * as tempy from 'tempy'
+import { cleanupTempDir } from '../../../src/utils/temp-dir'
 import simpleGit from 'simple-git'
 import type { Mock } from 'vitest'
 import type { SyncReposSchema } from '../../../src/server/git/schema'
@@ -32,6 +33,7 @@ const fakeOctokitData = {
 
 vi.mock('simple-git')
 vi.mock('tempy', () => ({ temporaryDirectory: vi.fn() }))
+vi.mock('../../../src/utils/temp-dir', () => ({ cleanupTempDir: vi.fn() }))
 const simpleGitMock = simpleGit as unknown as Mock
 const gitMock = {
   addRemote: vi.fn(),
@@ -57,6 +59,8 @@ describe('Git controller', () => {
     gitMock.raw.mockReset()
     gitMock.reset.mockReset()
     gitMock.show.mockReset()
+    vi.mocked(cleanupTempDir).mockReset()
+    vi.mocked(cleanupTempDir).mockResolvedValue(undefined)
   })
 
   it('should not be syncable', async () => {
@@ -78,10 +82,10 @@ describe('Git controller', () => {
 
     vi.spyOn(auth, 'generateAuthUrl')
       .mockReturnValueOnce(
-        'https://x-access-token:contributionAccessToken@github.com/sourceOwner/sourceRepo',
+        'https://x-access-token@github.com/sourceOwner/sourceRepo',
       )
       .mockReturnValueOnce(
-        'https://x-access-token:privateAccessToken@github.com/destinationOwner/destinationRepo',
+        'https://x-access-token@github.com/destinationOwner/destinationRepo',
       )
     vi.mocked(tempy.temporaryDirectory).mockReturnValue('directory')
 
@@ -141,10 +145,10 @@ describe('Git controller', () => {
 
     vi.spyOn(auth, 'generateAuthUrl')
       .mockReturnValueOnce(
-        'https://x-access-token:contributionAccessToken@github.com/sourceOwner/sourceRepo',
+        'https://x-access-token@github.com/sourceOwner/sourceRepo',
       )
       .mockReturnValueOnce(
-        'https://x-access-token:privateAccessToken@github.com/destinationOwner/destinationRepo',
+        'https://x-access-token@github.com/destinationOwner/destinationRepo',
       )
     vi.mocked(tempy.temporaryDirectory).mockReturnValue('directory')
 
@@ -216,10 +220,10 @@ describe('Git controller', () => {
 
     vi.spyOn(auth, 'generateAuthUrl')
       .mockReturnValueOnce(
-        'https://x-access-token:contributionAccessToken@github.com/sourceOwner/sourceRepo',
+        'https://x-access-token@github.com/sourceOwner/sourceRepo',
       )
       .mockReturnValueOnce(
-        'https://x-access-token:privateAccessToken@github.com/destinationOwner/destinationRepo',
+        'https://x-access-token@github.com/destinationOwner/destinationRepo',
       )
     vi.mocked(tempy.temporaryDirectory).mockReturnValue('directory')
 
@@ -298,10 +302,10 @@ describe('Git controller', () => {
 
     vi.spyOn(auth, 'generateAuthUrl')
       .mockReturnValueOnce(
-        'https://x-access-token:contributionAccessToken@github.com/sourceOwner/sourceRepo',
+        'https://x-access-token@github.com/sourceOwner/sourceRepo',
       )
       .mockReturnValueOnce(
-        'https://x-access-token:privateAccessToken@github.com/destinationOwner/destinationRepo',
+        'https://x-access-token@github.com/destinationOwner/destinationRepo',
       )
     vi.mocked(tempy.temporaryDirectory).mockReturnValue('directory')
 
@@ -385,10 +389,10 @@ describe('Git controller', () => {
 
     vi.spyOn(auth, 'generateAuthUrl')
       .mockReturnValueOnce(
-        'https://x-access-token:contributionAccessToken@github.com/sourceOwner/sourceRepo',
+        'https://x-access-token@github.com/sourceOwner/sourceRepo',
       )
       .mockReturnValueOnce(
-        'https://x-access-token:privateAccessToken@github.com/destinationOwner/destinationRepo',
+        'https://x-access-token@github.com/destinationOwner/destinationRepo',
       )
     vi.mocked(tempy.temporaryDirectory).mockReturnValue('directory')
 
@@ -443,5 +447,119 @@ describe('Git controller', () => {
     expect(gitMock.reset).toHaveBeenCalledWith(['--hard', 'HEAD^2'])
     expect(gitMock.push).toHaveBeenCalledTimes(1)
     expect(gitMock.push).toHaveBeenCalledWith(['--no-verify', '--force'])
+  })
+
+  it('cleans up the temp directory after a successful sync', async () => {
+    getRefSpy
+      .mockResolvedValueOnce({ data: { object: { sha: 'source-sha' } } })
+      .mockResolvedValueOnce({ data: { object: { sha: 'destination-sha' } } })
+
+    vi.spyOn(auth, 'generateAuthUrl')
+      .mockReturnValueOnce(
+        'https://x-access-token@github.com/sourceOwner/sourceRepo',
+      )
+      .mockReturnValueOnce(
+        'https://x-access-token@github.com/destinationOwner/destinationRepo',
+      )
+    vi.mocked(tempy.temporaryDirectory).mockReturnValue('sync-success')
+
+    gitMock.raw.mockResolvedValueOnce('')
+
+    await syncReposHandler({
+      input: {
+        source: {
+          org: 'sourceOrg',
+          repo: 'sourceRepo',
+          branch: 'sourceBranch',
+          octokit: fakeOctokitData,
+        },
+        destination: {
+          org: 'destinationOrg',
+          repo: 'destinationRepo',
+          branch: 'destinationBranch',
+          octokit: fakeOctokitData,
+        },
+        removeHeadMergeCommit: false,
+      },
+    })
+
+    expect(cleanupTempDir).toHaveBeenCalledTimes(1)
+    expect(cleanupTempDir).toHaveBeenCalledWith(
+      'sync-success',
+      expect.anything(),
+    )
+  })
+
+  it('cleans up the temp directory when sync throws', async () => {
+    // Force an early failure: the first getRef call rejects.
+    getRefSpy.mockRejectedValueOnce(new Error('upstream getRef failed'))
+    vi.mocked(tempy.temporaryDirectory).mockReturnValue('sync-error')
+
+    const response = await syncReposHandler({
+      input: {
+        source: {
+          org: 'sourceOrg',
+          repo: 'sourceRepo',
+          branch: 'sourceBranch',
+          octokit: fakeOctokitData,
+        },
+        destination: {
+          org: 'destinationOrg',
+          repo: 'destinationRepo',
+          branch: 'destinationBranch',
+          octokit: fakeOctokitData,
+        },
+        removeHeadMergeCommit: false,
+      },
+    })
+
+    // The error happened before temporaryDirectory() was called, so cleanup
+    // is invoked with undefined (no-op via the helper's own contract).
+    expect(response).toEqual({ success: false })
+    expect(cleanupTempDir).toHaveBeenCalledTimes(1)
+    expect(cleanupTempDir).toHaveBeenCalledWith(undefined, expect.anything())
+  })
+
+  it('cleans up the temp directory when sync throws after creating the temp dir', async () => {
+    getRefSpy
+      .mockResolvedValueOnce({ data: { object: { sha: 'source-sha' } } })
+      .mockResolvedValueOnce({ data: { object: { sha: 'destination-sha' } } })
+
+    vi.spyOn(auth, 'generateAuthUrl')
+      .mockReturnValueOnce(
+        'https://x-access-token@github.com/sourceOwner/sourceRepo',
+      )
+      .mockReturnValueOnce(
+        'https://x-access-token@github.com/destinationOwner/destinationRepo',
+      )
+    vi.mocked(tempy.temporaryDirectory).mockReturnValue('sync-late-error')
+
+    // Make a git operation that runs after temporaryDirectory() throw.
+    gitMock.checkoutBranch.mockRejectedValueOnce(new Error('checkout failed'))
+
+    const response = await syncReposHandler({
+      input: {
+        source: {
+          org: 'sourceOrg',
+          repo: 'sourceRepo',
+          branch: 'sourceBranch',
+          octokit: fakeOctokitData,
+        },
+        destination: {
+          org: 'destinationOrg',
+          repo: 'destinationRepo',
+          branch: 'destinationBranch',
+          octokit: fakeOctokitData,
+        },
+        removeHeadMergeCommit: false,
+      },
+    })
+
+    expect(response).toEqual({ success: false })
+    expect(cleanupTempDir).toHaveBeenCalledTimes(1)
+    expect(cleanupTempDir).toHaveBeenCalledWith(
+      'sync-late-error',
+      expect.anything(),
+    )
   })
 })

--- a/test/server/repos.test.ts
+++ b/test/server/repos.test.ts
@@ -15,8 +15,18 @@ vi.mock('simple-git', () => ({
   default: () => stubbedGit,
 }))
 
+vi.mock('tempy', () => ({
+  temporaryDirectory: vi.fn(),
+}))
+
+vi.mock('../../src/utils/temp-dir', () => ({
+  cleanupTempDir: vi.fn(),
+}))
+
 import * as config from '../../src/bot/config'
 import * as auth from '../../src/utils/auth'
+import * as tempy from 'tempy'
+import { cleanupTempDir } from '../../src/utils/temp-dir'
 import reposRouter from '../../src/server/repos/router'
 import { Octomock } from '../octomock'
 import { createTestContext } from '../utils/auth'
@@ -122,6 +132,8 @@ describe('Repos router', () => {
     // Default to a small commit count so the chunked push loop is skipped and
     // only the final tip push runs. Tests that exercise chunking override this.
     stubbedGit.raw.mockResolvedValue('2\n')
+    vi.mocked(tempy.temporaryDirectory).mockReturnValue('mirror-test-dir')
+    vi.mocked(cleanupTempDir).mockResolvedValue(undefined)
   })
 
   it('should create a mirror when repo does not exist', async () => {
@@ -691,6 +703,199 @@ describe('Repos router', () => {
         ref: 'heads/to-delete',
       })
       expect(res.success).toBe(true)
+    })
+  })
+
+  describe('temp directory cleanup', () => {
+    it('cleans up the temp directory after a successful in-window mirror', async () => {
+      const caller = t.createCallerFactory(reposRouter)(createTestContext())
+
+      vi.spyOn(config, 'getConfig').mockResolvedValue({
+        publicOrg: 'github',
+        privateOrg: 'github-test',
+      })
+
+      om.mockFunctions.rest.apps.getOrgInstallation.mockResolvedValue(
+        fakeOrgInstallation,
+      )
+      om.mockFunctions.rest.orgs.get.mockResolvedValue(fakeOrg)
+      om.mockFunctions.rest.repos.get.mockResolvedValueOnce(repoNotFound)
+      om.mockFunctions.rest.repos.get.mockResolvedValueOnce(fakeForkRepo)
+      om.mockFunctions.rest.git.getRef.mockResolvedValue(fakeBranchRef)
+      om.mockFunctions.rest.git.createRef.mockResolvedValue({ status: 201 })
+      om.mockFunctions.rest.orgs.getAllCustomProperties.mockResolvedValue(
+        fakeOrgCustomProperties,
+      )
+      om.mockFunctions.rest.repos.createInOrg.mockResolvedValue(fakeMirrorRepo)
+
+      vi.mocked(tempy.temporaryDirectory).mockReturnValue('temp-dir-success')
+
+      await caller.createMirror({
+        forkId: 'test',
+        orgId: 'test',
+        forkRepoName: 'fork-test',
+        forkRepoOwner: 'github',
+        newRepoName: 'test',
+      })
+
+      expect(cleanupTempDir).toHaveBeenCalledTimes(1)
+      expect(cleanupTempDir).toHaveBeenCalledWith(
+        'temp-dir-success',
+        expect.anything(),
+      )
+    })
+
+    it('cleans up the temp directory when in-window git work fails', async () => {
+      const caller = t.createCallerFactory(reposRouter)(createTestContext())
+
+      vi.spyOn(config, 'getConfig').mockResolvedValue({
+        publicOrg: 'github',
+        privateOrg: 'github-test',
+      })
+
+      om.mockFunctions.rest.apps.getOrgInstallation.mockResolvedValue(
+        fakeOrgInstallation,
+      )
+      om.mockFunctions.rest.orgs.get.mockResolvedValue(fakeOrg)
+      om.mockFunctions.rest.repos.get.mockResolvedValueOnce(repoNotFound)
+      om.mockFunctions.rest.repos.get.mockResolvedValueOnce(fakeForkRepo)
+      om.mockFunctions.rest.git.getRef.mockResolvedValue(fakeBranchRef)
+      om.mockFunctions.rest.git.createRef.mockResolvedValue({ status: 201 })
+      om.mockFunctions.rest.orgs.getAllCustomProperties.mockResolvedValue(
+        fakeOrgCustomProperties,
+      )
+      om.mockFunctions.rest.repos.createInOrg.mockResolvedValue(fakeMirrorRepo)
+      om.mockFunctions.rest.repos.delete.mockResolvedValue({})
+      om.mockFunctions.rest.git.deleteRef.mockResolvedValue({})
+
+      vi.mocked(tempy.temporaryDirectory).mockReturnValue('temp-dir-failure')
+
+      // Force in-window failure: clone rejects synchronously, before timeout.
+      stubbedGit.clone.mockRejectedValue(new Error('clone failed'))
+
+      await expect(
+        caller.createMirror({
+          forkId: 'test',
+          orgId: 'test',
+          forkRepoName: 'fork-test',
+          forkRepoOwner: 'github',
+          newRepoName: 'test',
+        }),
+      ).rejects.toThrow()
+
+      expect(cleanupTempDir).toHaveBeenCalledTimes(1)
+      expect(cleanupTempDir).toHaveBeenCalledWith(
+        'temp-dir-failure',
+        expect.anything(),
+      )
+    })
+
+    it('calls cleanupTempDir with undefined when an error occurs before the temp directory is created', async () => {
+      const caller = t.createCallerFactory(reposRouter)(createTestContext())
+
+      vi.spyOn(config, 'getConfig').mockResolvedValue({
+        publicOrg: 'github',
+        privateOrg: 'github-test',
+      })
+
+      om.mockFunctions.rest.apps.getOrgInstallation.mockResolvedValue(
+        fakeOrgInstallation,
+      )
+      om.mockFunctions.rest.orgs.get.mockResolvedValue(fakeOrg)
+      om.mockFunctions.rest.repos.get.mockResolvedValueOnce(repoNotFound)
+      om.mockFunctions.rest.repos.get.mockResolvedValueOnce(fakeForkRepo)
+      om.mockFunctions.rest.git.getRef.mockResolvedValue(fakeBranchRef)
+      om.mockFunctions.rest.git.createRef.mockResolvedValue({ status: 201 })
+      om.mockFunctions.rest.orgs.getAllCustomProperties.mockResolvedValue(
+        fakeOrgCustomProperties,
+      )
+      om.mockFunctions.rest.repos.delete.mockResolvedValue({})
+      om.mockFunctions.rest.git.deleteRef.mockResolvedValue({})
+
+      // Fail before tempDir is created — createInOrg runs before
+      // temporaryDirectory() in the controller.
+      om.mockFunctions.rest.repos.createInOrg.mockRejectedValue(
+        new Error('createInOrg failed'),
+      )
+
+      await expect(
+        caller.createMirror({
+          forkId: 'test',
+          orgId: 'test',
+          forkRepoName: 'fork-test',
+          forkRepoOwner: 'github',
+          newRepoName: 'test',
+        }),
+      ).rejects.toThrow()
+
+      expect(cleanupTempDir).toHaveBeenCalledTimes(1)
+      expect(cleanupTempDir).toHaveBeenCalledWith(undefined, expect.anything())
+    })
+
+    it('cleans up the temp directory after a successful background mirror', async () => {
+      const caller = t.createCallerFactory(reposRouter)(createTestContext())
+
+      vi.spyOn(config, 'getConfig').mockResolvedValue({
+        publicOrg: 'github',
+        privateOrg: 'github-test',
+      })
+
+      om.mockFunctions.rest.apps.getOrgInstallation.mockResolvedValue(
+        fakeOrgInstallation,
+      )
+      om.mockFunctions.rest.orgs.get.mockResolvedValue(fakeOrg)
+      om.mockFunctions.rest.repos.get.mockResolvedValueOnce(repoNotFound)
+      om.mockFunctions.rest.repos.get.mockResolvedValueOnce(fakeForkRepo)
+      om.mockFunctions.rest.git.getRef.mockResolvedValue(fakeBranchRef)
+      om.mockFunctions.rest.git.createRef.mockResolvedValue({ status: 201 })
+      om.mockFunctions.rest.orgs.getAllCustomProperties.mockResolvedValue(
+        fakeOrgCustomProperties,
+      )
+      om.mockFunctions.rest.repos.createInOrg.mockResolvedValue(fakeMirrorRepo)
+
+      vi.mocked(tempy.temporaryDirectory).mockReturnValue('temp-dir-pending')
+
+      // Hold the final push until after the timeout so the pending path is
+      // taken; then resolve it to simulate background success.
+      let resolvePush: () => void = () => {}
+      const pushPromise = new Promise<void>((resolve) => {
+        resolvePush = resolve
+      })
+      stubbedGit.clone.mockResolvedValue({})
+      stubbedGit.addRemote.mockResolvedValue({})
+      stubbedGit.push.mockReturnValue(pushPromise)
+
+      // Resolve when cleanup runs so the test waits for it.
+      const cleanupCalled = new Promise<void>((resolve) => {
+        vi.mocked(cleanupTempDir).mockImplementation(async () => {
+          resolve()
+        })
+      })
+
+      vi.stubEnv('MIRROR_SYNC_TIMEOUT_MS', '50')
+
+      const res = await caller.createMirror({
+        forkId: 'test',
+        orgId: 'test',
+        forkRepoName: 'fork-test',
+        forkRepoOwner: 'github',
+        newRepoName: 'test',
+      })
+
+      expect(res).toEqual({
+        success: true,
+        pending: true,
+        data: fakeMirrorRepo.data,
+      })
+
+      // Trip the background success and wait for cleanup.
+      resolvePush()
+      await cleanupCalled
+
+      expect(cleanupTempDir).toHaveBeenCalledWith(
+        'temp-dir-pending',
+        expect.anything(),
+      )
     })
   })
 })

--- a/test/utils.test.ts
+++ b/test/utils.test.ts
@@ -1,0 +1,54 @@
+import { vi, describe, beforeEach, it, expect } from 'vitest'
+import { rm } from 'node:fs/promises'
+import { cleanupTempDir } from '../src/utils/temp-dir'
+import type { Logger } from 'tslog'
+
+vi.mock('node:fs/promises', () => ({
+  rm: vi.fn(),
+}))
+
+const fakeLogger = {
+  warn: vi.fn(),
+} as unknown as Logger<unknown>
+
+describe('cleanupTempDir', () => {
+  beforeEach(() => {
+    vi.mocked(rm).mockReset()
+    vi.mocked(fakeLogger.warn).mockReset()
+  })
+
+  it('removes the directory recursively and forcefully', async () => {
+    vi.mocked(rm).mockResolvedValue(undefined)
+
+    await cleanupTempDir('temp-dir', fakeLogger)
+
+    expect(rm).toHaveBeenCalledTimes(1)
+    expect(rm).toHaveBeenCalledWith('temp-dir', {
+      recursive: true,
+      force: true,
+    })
+    expect(fakeLogger.warn).not.toHaveBeenCalled()
+  })
+
+  it('is a no-op when tempDir is undefined', async () => {
+    await cleanupTempDir(undefined, fakeLogger)
+
+    expect(rm).not.toHaveBeenCalled()
+    expect(fakeLogger.warn).not.toHaveBeenCalled()
+  })
+
+  it('swallows and logs rm errors instead of throwing', async () => {
+    const rmError = new Error('permission denied')
+    vi.mocked(rm).mockRejectedValue(rmError)
+
+    await expect(
+      cleanupTempDir('temp-dir', fakeLogger),
+    ).resolves.toBeUndefined()
+
+    expect(fakeLogger.warn).toHaveBeenCalledTimes(1)
+    expect(fakeLogger.warn).toHaveBeenCalledWith(
+      'Failed to clean up temp directory',
+      { tempDir: 'temp-dir', error: rmError },
+    )
+  })
+})


### PR DESCRIPTION
# Pull Request

<!--
PR title needs to be prefixed with a conventional commit type
(build,chore,ci,docs,feat,fix,perf,refactor,revert,style,test)

It should also be brief and descriptive for a good changelog entry

examples: "feat: add new logger" or "fix: remove unused imports"
-->

## Proposed Changes

<!-- Describe what the changes are and link to a GitHub Issue if one exists -->

This change fixes an issue where the lack of temporary directory deletion after mirror creation or syncing can cause the application storage to get full over time and eventually result in failures. This was fixed by adding a helper function to cleanup a passed in temporary directory and ensuring that all exit points where a temporary directory was created have the cleanup function called.

## Readiness Checklist

### Author/Contributor

- [x] If documentation is needed for this change, has that been included in this pull request
- [x] run `npm run format` and fix any formatting issues that have been introduced
- [x] run `npm run lint` and fix any linting issues that have been introduced
- [x] run `npm run test` and run tests
