### PR TITLE
feat: add feature toggle to disable mirror deletion

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -42,3 +42,6 @@ MIRROR_SYNC_TIMEOUT_MS=
 
 # Used to configure the number of commits to push at a time when syncing a mirror (default is 100)
 MIRROR_PUSH_CHUNK_SIZE=
+
+# Used to disable mirror deletion through private mirrors. Hides the delete action in the UI and rejects direct API calls.
+DISABLE_MIRROR_DELETION=

--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,4 @@ build
 !.env.example
 .DS_Store
 next-env.d.ts
+tsconfig.tsbuildinfo

--- a/env.mjs
+++ b/env.mjs
@@ -92,6 +92,11 @@ export const env = createEnv({
         }
         return parsed
       }),
+    DISABLE_MIRROR_DELETION: z
+      .enum(['true', 'false', ''])
+      .optional()
+      .default('false')
+      .transform((value) => value === 'true'),
   },
   /*
    * Environment variables available on the client (and server).
@@ -127,6 +132,7 @@ export const env = createEnv({
       process.env.DELETE_INTERNAL_MERGE_COMMITS_ON_SYNC,
     MIRROR_SYNC_TIMEOUT_MS: process.env.MIRROR_SYNC_TIMEOUT_MS,
     MIRROR_PUSH_CHUNK_SIZE: process.env.MIRROR_PUSH_CHUNK_SIZE,
+    DISABLE_MIRROR_DELETION: process.env.DISABLE_MIRROR_DELETION,
   },
   skipValidation: process.env.SKIP_ENV_VALIDATIONS === 'true',
 })

--- a/src/app/[organizationId]/forks/[forkId]/page.tsx
+++ b/src/app/[organizationId]/forks/[forkId]/page.tsx
@@ -19,7 +19,7 @@ import {
   RelativeTime,
   Stack,
 } from '@primer/react'
-import { Blankslate, DataTable, Table } from '@primer/react/drafts'
+import { Blankslate, DataTable, Table, Tooltip } from '@primer/react/drafts'
 import { ForkBreadcrumbs } from 'app/components/breadcrumbs/ForkBreadcrumbs'
 import { CreateMirrorDialog } from 'app/components/dialog/CreateMirrorDialog'
 import { DeleteMirrorDialog } from 'app/components/dialog/DeleteMirrorDialog'
@@ -185,7 +185,7 @@ const Fork = () => {
   } = trpc.createMirror.useMutation()
 
   const {
-    data: mirrors,
+    data: mirrorsData,
     isLoading: mirrorsLoading,
     refetch: refetchMirrors,
     error: listMirrorsError,
@@ -198,6 +198,8 @@ const Fork = () => {
       enabled: Boolean(organizationId) && Boolean(forkData?.data?.name),
     },
   )
+  const mirrors = mirrorsData?.mirrors
+  const mirrorDeletionEnabled = mirrorsData?.mirrorDeletionEnabled ?? false
 
   const {
     data: editMirrorData,
@@ -608,6 +610,23 @@ const Fork = () => {
               width: '50px',
               align: 'end',
               renderCell: (row) => {
+                const deleteItem = (
+                  <ActionList.Item
+                    variant="danger"
+                    disabled={!mirrorDeletionEnabled}
+                    onSelect={() =>
+                      openDeleteDialog(row.name, mirrorPaginationSet.length)
+                    }
+                  >
+                    <Stack align="center" direction="horizontal">
+                      <Stack.Item>
+                        <Octicon icon={TrashIcon}></Octicon>
+                      </Stack.Item>
+                      <Stack.Item>Delete mirror</Stack.Item>
+                    </Stack>
+                  </ActionList.Item>
+                )
+
                 return (
                   <ActionMenu>
                     <ActionMenu.Anchor>
@@ -631,22 +650,16 @@ const Fork = () => {
                             <Stack.Item>Edit mirror</Stack.Item>
                           </Stack>
                         </ActionList.Item>
-                        <ActionList.Item
-                          variant="danger"
-                          onSelect={() => {
-                            openDeleteDialog(
-                              row.name,
-                              mirrorPaginationSet.length,
-                            )
-                          }}
-                        >
-                          <Stack align="center" direction="horizontal">
-                            <Stack.Item>
-                              <Octicon icon={TrashIcon}></Octicon>
-                            </Stack.Item>
-                            <Stack.Item>Delete mirror</Stack.Item>
-                          </Stack>
-                        </ActionList.Item>
+                        {mirrorDeletionEnabled ? (
+                          deleteItem
+                        ) : (
+                          <Tooltip
+                            direction="s"
+                            text="Mirror deletion has been disabled in the application settings"
+                          >
+                            <Box as="span">{deleteItem}</Box>
+                          </Tooltip>
+                        )}
                       </ActionList>
                     </ActionMenu.Overlay>
                   </ActionMenu>

--- a/src/server/repos/controller.ts
+++ b/src/server/repos/controller.ts
@@ -391,7 +391,10 @@ export const listMirrorsHandler = async ({
       (response) => response.data,
     )
 
-    return repos
+    return {
+      mirrors: repos,
+      mirrorDeletionEnabled: process.env.DISABLE_MIRROR_DELETION !== 'true',
+    }
   } catch (error) {
     reposApiLogger.info('Failed to fetch mirrors', { input, error })
 
@@ -485,6 +488,13 @@ export const deleteMirrorHandler = async ({
 }: {
   input: DeleteMirrorSchema
 }) => {
+  if (process.env.DISABLE_MIRROR_DELETION === 'true') {
+    throw new TRPCError({
+      code: 'FORBIDDEN',
+      message: 'Mirror deletion is disabled',
+    })
+  }
+
   try {
     reposApiLogger.info('Deleting mirror', { input })
 

--- a/test/octomock/index.ts
+++ b/test/octomock/index.ts
@@ -308,13 +308,18 @@ const mockFunctions = {
       createRef: vi.fn(),
       deleteRef: vi.fn(),
     },
+    search: {
+      repos: vi.fn(),
+    },
   },
+  paginate: vi.fn(),
 }
 
 export class Octomock {
   mockFunctions: {
     rest: Record<string, Record<string, Mock>>
     config: Record<string, Mock>
+    paginate: Mock
   }
   defaultContext: { payload: { issue: { body: string; user: object } } }
 

--- a/test/server/repos.test.ts
+++ b/test/server/repos.test.ts
@@ -657,6 +657,63 @@ describe('Repos router', () => {
     })
   })
 
+  describe('listMirror', () => {
+    const fakeMirrorList = [{ name: 'mirror-1' }, { name: 'mirror-2' }]
+
+    const setupListMirrorsMocks = () => {
+      vi.spyOn(config, 'getConfig').mockResolvedValue({
+        publicOrg: 'github',
+        privateOrg: 'github-test',
+      })
+
+      om.mockFunctions.rest.apps.getOrgInstallation.mockResolvedValue(
+        fakeOrgInstallation,
+      )
+      om.mockFunctions.rest.orgs.get.mockResolvedValue(fakeOrg)
+      om.mockFunctions.paginate.mockResolvedValue(fakeMirrorList)
+    }
+
+    it('returns mirrorDeletionEnabled: true when DISABLE_MIRROR_DELETION is unset', async () => {
+      const caller = t.createCallerFactory(reposRouter)(createTestContext())
+      setupListMirrorsMocks()
+
+      const res = await caller.listMirrors({
+        orgId: 'test',
+        forkName: 'fork-test',
+      })
+
+      expect(res.mirrors).toEqual(fakeMirrorList)
+      expect(res.mirrorDeletionEnabled).toBe(true)
+    })
+
+    it('returns mirrorDeletionEnabled: false when DISABLE_MIRROR_DELETION is "true"', async () => {
+      const caller = t.createCallerFactory(reposRouter)(createTestContext())
+      setupListMirrorsMocks()
+      vi.stubEnv('DISABLE_MIRROR_DELETION', 'true')
+
+      const res = await caller.listMirrors({
+        orgId: 'test',
+        forkName: 'fork-test',
+      })
+
+      expect(res.mirrors).toEqual(fakeMirrorList)
+      expect(res.mirrorDeletionEnabled).toBe(false)
+    })
+
+    it('returns mirrorDeletionEnabled: true when DISABLE_MIRROR_DELETION is "false"', async () => {
+      const caller = t.createCallerFactory(reposRouter)(createTestContext())
+      setupListMirrorsMocks()
+      vi.stubEnv('DISABLE_MIRROR_DELETION', 'false')
+
+      const res = await caller.listMirrors({
+        orgId: 'test',
+        forkName: 'fork-test',
+      })
+
+      expect(res.mirrorDeletionEnabled).toBe(true)
+    })
+  })
+
   describe('deleteMirror', () => {
     it('deletes the mirror and the sync branch ref on the public fork', async () => {
       const caller = t.createCallerFactory(reposRouter)(createTestContext())
@@ -691,6 +748,24 @@ describe('Repos router', () => {
         ref: 'heads/to-delete',
       })
       expect(res.success).toBe(true)
+    })
+
+    it('throws FORBIDDEN when DISABLE_MIRROR_DELETION is "true"', async () => {
+      const caller = t.createCallerFactory(reposRouter)(createTestContext())
+      vi.stubEnv('DISABLE_MIRROR_DELETION', 'true')
+
+      await expect(
+        caller.deleteMirror({
+          orgId: 'test',
+          mirrorName: 'to-delete',
+        }),
+      ).rejects.toMatchObject({
+        code: 'FORBIDDEN',
+        message: 'Mirror deletion is disabled',
+      })
+
+      expect(om.mockFunctions.rest.repos.delete).not.toHaveBeenCalled()
+      expect(om.mockFunctions.rest.git.deleteRef).not.toHaveBeenCalled()
     })
   })
 })


### PR DESCRIPTION
# Pull Request

<!--
PR title needs to be prefixed with a conventional commit type
(build,chore,ci,docs,feat,fix,perf,refactor,revert,style,test)

It should also be brief and descriptive for a good changelog entry

examples: "feat: add new logger" or "fix: remove unused imports"
-->

## Proposed Changes

<!-- Describe what the changes are and link to a GitHub Issue if one exists -->

This change adds a feature toggle environment variable that can be used to disable deleting mirrors through the Private Mirrors UI. The change works by both disabling the delete button in the UI with a tooltip to explain that it is disabled and updating the API to throw an error if the delete endpoint is hit directly. Also included is an update to the .gitignore to exclude the generated tsconfig.tsbuildinfo from version control.

## Readiness Checklist

### Author/Contributor

- [x] If documentation is needed for this change, has that been included in this pull request
- [x] run `npm run format` and fix any formatting issues that have been introduced
- [x] run `npm run lint` and fix any linting issues that have been introduced
- [x] run `npm run test` and run tests
